### PR TITLE
Escape / replace spec chars

### DIFF
--- a/influxdb/influxdb-neb.lua
+++ b/influxdb/influxdb-neb.lua
@@ -145,12 +145,14 @@ function EventQueue:add(e)
     end
     -- message format : <measurement>[,<tag-key>=<tag-value>...]
     --  <field-key>=<field-value>[,<field2-key>=<field2-value>...] [unix-nano-timestamp]
+    -- some charaters [ ,=] must be escaped, let's replace them by _ for better handling
     -- consider space in service_description as a separator for an item tag
     local item = ""
-    if string.find(service_description, " ") then
-        item = ",item=" .. string.gsub(service_description, ".* ", "")
-        service_description = string.gsub(service_description, " .*", "")
+    if string.find(service_description, " [^ ]+$") then
+        item = ",item=" .. string.gsub(string.gsub(service_description, ".* ", "", 1), "[ ,=]+" ,"_")
+        service_description = string.gsub(service_description, " +[^ ]+$", "", 1)
     end
+    service_description = string.gsub(service_description, "[ ,=]+" ,"_")
     -- define messages from perfata, transforming instance names to inst tags, which leads to one message per instance
     local instances = {}
     for m,v in pairs(perfdata) do
@@ -158,7 +160,7 @@ function EventQueue:add(e)
         if not inst then
             inst = ""
         else
-            inst = ",inst=" .. inst
+            inst = ",inst=" .. string.gsub(inst, "[ ,=]+" ,"_")
         end
         if not instances[inst] then
             instances[inst] = self.measurement .. service_description .. ",host=" .. host_name .. item .. inst .. " "

--- a/influxdb/influxdb-neb.lua
+++ b/influxdb/influxdb-neb.lua
@@ -145,7 +145,7 @@ function EventQueue:add(e)
     end
     -- message format : <measurement>[,<tag-key>=<tag-value>...]
     --  <field-key>=<field-value>[,<field2-key>=<field2-value>...] [unix-nano-timestamp]
-    -- some charaters [ ,=] must be escaped, let's replace them by _ for better handling
+    -- some characters [ ,=] must be escaped, let's replace them by _ for better handling
     -- consider space in service_description as a separator for an item tag
     local item = ""
     if string.find(service_description, " [^ ]+$") then


### PR DESCRIPTION
Hi,

This PR escapes / replaces special characters in measurements and tags.
https://docs.influxdata.com/influxdb/v0.9/write_protocols/write_syntax/#escaping-characters

As an example, `network::mikrotik::snmp::plugin`, mode `memory`, returns the following perfdata :
`'main memory#storage.space.usage.percentage'=5.33%;0.00:80.00;0.00:90.00;0;100`

We now have in InfluxDB the following series :
`sys-memory,host=firewall01,inst=main_memory`

Thank you :+1: