### PR TITLE
fix(influx) Ignore time metric

### DIFF
--- a/influxdb/influxdb-neb.lua
+++ b/influxdb/influxdb-neb.lua
@@ -165,7 +165,7 @@ function EventQueue:add(e)
         else
             inst = ",inst=" .. string.gsub(inst, "[ ,=]+", self.replacement_character)
         end
-        if not e.service_id or string.match(metric, ".+[.].+") then
+        if (not e.service_id and metric ~= "time") or string.match(metric, ".+[.].+") then
             if not instances[inst] then
                 instances[inst] = self.measurement .. service_description .. ",host=" .. host_name .. item .. inst .. " "
             end


### PR DESCRIPTION
Hi,

Let's get rid of unsupported "time" metric, as it's already used internally by InfluxDB.
This then closes #32.

Thx 👍 