### PR TITLE
Fix hostgroups for services + state change condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,8 +530,8 @@ Extra informations are added to the host and services as bellow :
 
 - action_url
 - notes_url
+- hostgroups
 - servicegroups (for service events)
-- hostgroups (for host events)
 
 ### Acknowledgment
 

--- a/canopsis/bbdo2canopsis.lua
+++ b/canopsis/bbdo2canopsis.lua
@@ -297,7 +297,8 @@ local function canopsisMapping(d)
       -- extra informations
       servicegroups = getServiceGroups(d.host_id, d.service_id),
       notes_url = getNotesURL(d.host_id, d.service_id),
-      action_url = getActionURL(d.host_id, d.service_id)
+      action_url = getActionURL(d.host_id, d.service_id),
+      hostgroups = getHostGroups(d.host_id)
     }
     debug("Streaming SERVICE STATUS for service_id ".. d.service_id)
   -- ACK
@@ -390,7 +391,9 @@ function stateChanged(d)
   if d.state_type == 1 and -- if the event is in hard state
      d.last_hard_state_change ~= nil then -- if the event has been in a hard state
 
-    if d.last_check == d.last_hard_state_change then -- if the state has changed
+    -- if the state has changed 
+    -- (like noted in the omi connector, it could have a slight delta between last_check and last_hard_state_change)
+    if math.abs(d.last_check - d.last_hard_state_change) < 10 then
 
       if d.service_id then
         debug("HARD state change detected for service_id [" .. d.service_id .. "]")


### PR DESCRIPTION
Script improvements :

- hostgroups are available as extra informations for service events
- the state change filter has changed to be more tolerant