### PR TITLE
fix(influxdb) events may not have last_check value

### DIFF
--- a/centreon-certified/influxdb/influxdb-neb-apiv1.lua
+++ b/centreon-certified/influxdb/influxdb-neb-apiv1.lua
@@ -119,7 +119,7 @@ function EventQueue:add(e)
         perfdata = {}
     end
     -- retrieve and store state for further processing
-    if self.skip_events_state == 0 then
+    if self.skip_events_state == 0 and e.last_check ~= nil then
         perfdata["centreon.state"] = e.state
         perfdata["centreon.state_type"] = e.state_type
     elseif perfdata_err then


### PR DESCRIPTION
Hi,

This follows #43.
Some events arrive without `perfdata`, which is expected, but also without `last_check` value.
In this case, we must skip the event (as we can't then compute `perfdate`).

Thx 👍