### PR TITLE
enh(influxdb) get rid of deduplicate

### DIFF
--- a/centreon-certified/influxdb/influxdb-neb-apiv1.lua
+++ b/centreon-certified/influxdb/influxdb-neb-apiv1.lua
@@ -101,17 +101,8 @@ end
 -- @param e An event
 --------------------------------------------------------------------------------
 
-local previous_event = ""
-
 function EventQueue:add(e)
-    -- workaround https://github.com/centreon/centreon-broker/issues/201
-    current_event = broker.json_encode(e)
-    if current_event == previous_event then
-        broker_log:info(3, "EventQueue:add: Duplicate event ignored.")
-        return false
-    end
-    previous_event = current_event
-    broker_log:info(3, "EventQueue:add: " .. current_event)
+    broker_log:info(3, "EventQueue:add: " .. broker.json_encode(e))
     -- let's get and verify we have perfdata
     local perfdata, perfdata_err = broker.parse_perfdata(e.perfdata)
     if perfdata_err then


### PR DESCRIPTION
Hi,

Now that the root-cause has been solved on engine side (https://github.com/centreon/centreon-broker/issues/201#issuecomment-895273792) by @bouda1, let's get rid of the dedup function here, which will save some CPU time...

Thank you 👍
