### PR TITLE
(lib)sc_macro fix buggy transform_date function

### DIFF
--- a/modules/centreon-stream-connectors-lib/sc_macros.lua
+++ b/modules/centreon-stream-connectors-lib/sc_macros.lua
@@ -371,7 +371,7 @@ end
 -- @param macro_value (number) the timestamp that needs to be converted
 -- @return date (string) the converted timestamp
 function ScMacros:transform_date(macro_value)
-  return os.date(self.params.timestamp_conversion_format, os.time(os.date("!*t", macro_value) + self.params.local_time_diff_from_utc))
+  return os.date(self.params.timestamp_conversion_format, os.time(os.date("!*t", macro_value + self.params.local_time_diff_from_utc)))
 end
 
 --- transform_short: mostly used to convert the event output into a short output by keeping only the data before the new line


### PR DESCRIPTION
Today using transform_date function breaks event formatting and result in following error message in broker logs: 

```
[1638130892] error:   lua: error running function `write'/usr/share/lua/5.1/centreon-stream-connectors-lib/sc_macros.lua:374: attempt to perform arithmetic on a table value
```