### PR TITLE
handle last_check & last_update for better compat

### DIFF
--- a/modules/centreon-stream-connectors-lib/sc_event.lua
+++ b/modules/centreon-stream-connectors-lib/sc_event.lua
@@ -143,7 +143,15 @@ function ScEvent:is_valid_host_status_event()
     self.sc_logger:warning("[sc_event:is_valid_host_status_event]: host_id: " .. tostring(self.event.host_id) .. " is not in an accepted hostgroup")
     return false
   end
-  
+
+  -- in bbdo 2 last_update do exist but not in bbdo3.
+  -- last_check also exist in bbdo2 but it is preferable to stay compatible with all stream connectors
+  if not self.event.last_update and self.event.last_check then
+    self.event.last_update = self.event.last_check
+  elseif not self.event.last_check and self.event.last_update then
+    self.event.last_check = self.event.last_update
+  end
+
   self:build_outputs()
 
   return true
@@ -217,6 +225,14 @@ function ScEvent:is_valid_service_status_event()
   if not self:is_valid_servicegroup() then
     self.sc_logger:warning("[sc_event:is_valid_service_status_event]: service_id: " .. tostring(self.event.service_id) .. " is not in an accepted servicegroup")
     return false
+  end
+
+  -- in bbdo 2 last_update do exist but not in bbdo3.
+  -- last_check also exist in bbdo2 but it is preferable to stay compatible with all stream connectors
+  if not self.event.last_update and self.event.last_check then
+    self.event.last_update = self.event.last_check
+  elseif not self.event.last_check and self.event.last_update then
+    self.event.last_check = self.event.last_update
   end
 
   self:build_outputs()


### PR DESCRIPTION
## Description

this is a compatibility patch because we had the possibility to use the last_update info from host_status and service_status event but they are no longer available in the pb host status and pb service status. 

To have a seemless switch, the last_update value will be forced to be the last_check value if it is not there (and last_check will be forced to be last_update value if it is not present just in case)

**Fixes** #115 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

use pagerduty stream connector,
have an event for host 
without the patch the event will never be fired. with the patch it works fine for services and hosts

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
