### PR TITLE
Enhance macro system (new group macro + new transformation flags)

### DIFF
--- a/modules/centreon-stream-connectors-lib/sc_common.lua
+++ b/modules/centreon-stream-connectors-lib/sc_common.lua
@@ -221,57 +221,58 @@ end
 -- @param string (string) the string that must be escaped
 -- @return string (string) the string with escaped characters
 function ScCommon:json_escape(string)
-  local type = type(string)
-
-  -- check that param is a valid string
-  if string == nil or type == "table" then
-    self.sc_logger:error("[sc_common:json_escape]: the input parameter is not valid, it is either nil or a table. Sent value: " .. tostring(string))
+  if type(string) ~= "string" then
+    self.sc_logger:error("[sc_common:json_escape]: the input parameter is not valid, it must be a string. Sent value: " .. tostring(string))
     return string
   end
 
-  -- nothing to escape in a boolean or number value
-  if type ~= "string" then
-    return string
-  end
-
-  -- escape all characters
-  string = string.gsub(string, '\\', '\\\\')
-  string = string.gsub(string, '\t', '\\t')
-  string = string.gsub(string, '\n', '\\n')
-  string = string.gsub(string, '\b', '\\b')
-  string = string.gsub(string, '\r', '\\r')
-  string = string.gsub(string, '\f', '\\f')
-  string = string.gsub(string, '/', '\\/')
-  string = string.gsub(string, '"', '\\"')
-
-  return string
+  return string:gsub('\\', '\\\\')
+    :gsub('\t', '\\t')
+    :gsub('\n', '\\n')
+    :gsub('\b', '\\b')
+    :gsub('\r', '\\r')
+    :gsub('\f', '\\f')
+    :gsub('/', '\\/')
+    :gsub('"', '\\"')
 end
 
 --- xml_escape: escape xml special characters in a string
 -- @param string (string) the string that must be escaped
 -- @return string (string) the string with escaped characters
 function ScCommon:xml_escape(string)
-  local type = type(string)
-
-  -- check that param is a valid string
-  if string == nil or type == "table" then
-    self.sc_logger:error("[sc_common:xml_escape]: the input parameter is not valid, it is either nil or a table. Sent value: " .. tostring(string))
+  if type(string) ~= "string" then
+    self.sc_logger:error("[sc_common:xml_escape]: the input parameter is not valid, it must be a string. Sent value: " .. tostring(string))
     return string
   end
 
-  -- nothing to escape in a boolean or number value
-  if type ~= "string" then
+  return string:gsub('&', '&amp')
+    :gsub('<', '$lt;')
+    :gsub('>', '&gt;')
+    :gsub('"', '&quot;')
+    :gsub("'", "&apos;")
+end
+
+--- lua_regex_escape: escape lua regex special characters in a string
+-- @param string (string) the string that must be escaped
+-- @return string (string) the string with escaped characters
+function ScCommon:lua_regex_escape(string)
+  if type(string) ~= "string" then
+    self.sc_logger:error("[sc_common:lua_regex_escape]: the input parameter is not valid, it must be a string. Sent value: " .. tostring(string))
     return string
   end
 
-  -- escape all characters
-  string = string.gsub(string, '&', '&amp')
-  string = string.gsub(string, '<', '&lt;')
-  string = string.gsub(string, '>', '&gt;')
-  string = string.gsub(string, '"', '&quot;')
-  string = string.gsub(string, "'", "&apos;")
-
-  return string
+  return string:gsub('%%', '%%%%')
+    :gsub('%.', '%%.')
+    :gsub("%*", "%%*")
+    :gsub("%-", "%%-")
+    :gsub("%(", "%%(")
+    :gsub("%)", "%%)")
+    :gsub("%[", "%%[")
+    :gsub("%]", "%%]")
+    :gsub("%$", "%%$")
+    :gsub("%^", "%%^")
+    :gsub("%+", "%%+")
+    :gsub("%?", "%%?")
 end
 
 --- dumper: dump variables for debug purpose

--- a/modules/centreon-stream-connectors-lib/sc_common.lua
+++ b/modules/centreon-stream-connectors-lib/sc_common.lua
@@ -323,5 +323,20 @@ function ScCommon:dumper(variable, result, tab_char)
   return result
 end
 
+--- trim: remove spaces at the beginning and end of a string (or remove the provided character)
+-- @param string (string) the string that will be trimmed
+-- @param character [opt] (string) the character to trim
+-- @return string (string) the trimmed string
+function ScCommon:trim(string, character)
+  local result = ""
+  local count = ""
+  if not character then
+    result, count = string.gsub(string, "^%s*(.-)%s*$", "%1")
+  else
+    result, count = string.gsub(string, "^" .. character .. "*(.-)" .. character .. "*$", "%1")
+  end
+
+  return result
+end
 
 return sc_common

--- a/modules/centreon-stream-connectors-lib/sc_macros.lua
+++ b/modules/centreon-stream-connectors-lib/sc_macros.lua
@@ -213,14 +213,14 @@ function ScMacros:replace_sc_macro(string, event, json_string)
     
     -- replace all cache macro such as {cache.host.name} with their values
     if cache_macro_value then
-      converted_string = self:build_converted_string(cache_macro_value, macro, converted_string)
+      converted_string = self:build_converted_string_for_cache_and_event_macro(cache_macro_value, macro, converted_string)
     else
       -- if not in cache, try to find a matching value in the event itself
       event_macro_value = self:get_event_macro(macro, event)
       
       -- replace all event macro such as {host_id} with their values
       if event_macro_value then
-        converted_string = self:build_converted_string(event_macro_value, macro, converted_string)
+        converted_string = self:build_converted_string_for_cache_and_event_macro(event_macro_value, macro, converted_string)
       else
         -- if not event or cache macro, maybe it is a group macro
         group_macro_value, format = self:get_group_macro(macro, event)
@@ -550,12 +550,12 @@ end
 -- @param macro (string): the macro name
 -- @param converted_string (string): the string in which a macro must be replaced
 -- @return converted_string (string): the string with the macro replaced
-function ScMacros:build_converted_string(macro_value, macro, converted_string)
+function ScMacros:build_converted_string_for_cache_and_event_macro(macro_value, macro, converted_string)
   -- need to escape % characters or else it will break the string.gsub that is done later
   local clean_macro_value, _ = string.gsub(macro_value, "%%", "%%%%")
   local clean_macro_value_json = ""
   
-  self.sc_logger:debug("[sc_macros:build_converted_string]: macro is a cache macro. Macro name: "
+  self.sc_logger:debug("[sc_macros:build_converted_string_for_cache_and_event_macro]: macro is a cache macro. Macro name: "
   .. tostring(macro) .. ", value is: " .. tostring(clean_macro_value) .. ", trying to replace it in the string: " .. tostring(converted_string))
   
   --[[

--- a/modules/centreon-stream-connectors-lib/sc_macros.lua
+++ b/modules/centreon-stream-connectors-lib/sc_macros.lua
@@ -32,6 +32,19 @@ function sc_macros.new(params, logger, common)
   -- initiate params
   self.params = params
 
+  -- mapping to help get "group" type macros value
+  self.group_macro_conversion = {
+    hg = function(event, format, regex) return self:get_hg_macro(event, format, regex) end,
+    sg = function(event, format, regex) return self:get_sg_macro(event, format, regex) end,
+    bv = function(event, format, regex) return self:get_bv_macro(event, format, regex) end
+  }
+
+  -- mapping to help transform group macro values into a specific format
+  self.group_macro_format = {
+    table = function(data) return self:group_macro_format_table(data) end,
+    inline = function(data) return self:group_macro_format_inline(data) end
+  }
+
   -- mapping of macro that we will convert if asked
   self.transform_macro = {
     date = function (macro_value) return self:transform_date(macro_value) end,
@@ -183,12 +196,14 @@ end
 function ScMacros:replace_sc_macro(string, event, json_string)
   local cache_macro_value = false
   local event_macro_value = false
+  local group_macro_value = false
+  local format = false
   local converted_string = string
 
   -- find all macros for exemple the string: 
   -- {cache.host.name} is the name of host with id: {host_id} 
   -- will generate two macros {cache.host.name} and {host_id})
-  for macro in string.gmatch(string, "{[%w_.]+}") do
+  for macro in string.gmatch(string, "{[%w_.%(%),%%%+%-%*%?%[%]%^%$]+}") do
     self.sc_logger:debug("[sc_macros:replace_sc_macro]: found a macro, name is: " .. tostring(macro))
     
     -- check if macro is in the cache
@@ -216,12 +231,32 @@ function ScMacros:replace_sc_macro(string, event, json_string)
 
         -- if the input string was a json encoded string, we must make sure that the value we are going to insert is json ready
         if json_string then
-          cache_macro_value = self.sc_common:json_escape(cache_macro_value)
+          event_macro_value = self.sc_common:json_escape(event_macro_value)
         end
-        
+
         converted_string = string.gsub(converted_string, macro, self.sc_common:json_escape(string.gsub(event_macro_value, "%%", "%%%%")))
       else
-        self.sc_logger:error("[sc_macros:replace_sc_macro]: macro: " .. tostring(macro) .. ", is not a valid stream connector macro")
+        -- if not event or cache macro, maybe it is a group macro
+        group_macro_value, format = self:get_group_macro(macro, event)
+
+        -- replace all group macro such as {group(hg,table)} with their values
+        if group_macro_value then
+          group_macro_value= broker.json_encode(group_macro_value)
+          
+          self.sc_logger:debug("[sc_macros:replace_sc_macro]: macro is a group macro. Macro name: "
+            .. tostring(macro) .. ", value is: " .. tostring(group_macro_value) .. ", trying to replace it in the string: " .. tostring(converted_string)
+            .. ". Applied format is: " .. tostring(format))
+          
+          -- we don't need the gsub(value, "%%", "%%%%") because no group name can use the % character
+          -- if format and format == "table" then
+            -- need to remove double quotes in json to have a proper format
+            converted_string = string.gsub(converted_string, '"' .. self.sc_common:lua_regex_escape(macro) .. '"', group_macro_value)
+          -- else
+            -- converted_string = string.gsub(converted_string, self.sc_common:lua_regex_escape(macro), group_macro_value)
+          -- end
+        else
+          self.sc_logger:error("[sc_macros:replace_sc_macro]: macro: " .. tostring(macro) .. ", is not a valid stream connector macro")
+        end
       end
     end
   end
@@ -236,9 +271,11 @@ function ScMacros:replace_sc_macro(string, event, json_string)
       return converted_string
     end
 
+    self.sc_logger:debug("[sc_macros:replace_sc_macro]: decoded json: " .. self.sc_common:dumper(decoded_json))
     return decoded_json
   end
 
+  self.sc_logger:debug("[sc_macros:replace_sc_macro]: converted string: " .. tostring(converted_string))
   return converted_string
 end
 
@@ -306,6 +343,104 @@ function ScMacros:get_event_macro(macro, event)
   end
 
   return false
+end
+
+--- get_group_macro: check if the macro is a macro which value must be found in a group table (meaning it is a special kind of data in the event) 
+-- @param macro (string) the macro we want to check (for example: {group(hg,table)})
+-- @param event (table) the event table
+-- @return false (boolean) if the macro is not found
+-- @return macro_value (string|boolean|number) the value of the macro
+function ScMacros:get_group_macro(macro, event)
+  -- try to cut the macro 
+  local group_type, format, regex = string.match(macro, "^{groups%((%w+),(%w+),(.*)%)}")
+
+  if not group_type or not format or not regex or not self.group_macro_conversion[group_type] then
+    self.sc_logger:info("[sc_macros:get_group_macro]: macro: " .. tostring(macro) .. " is not a valid group macro")
+    return false
+  end
+
+  local data, index_name = self.group_macro_conversion[group_type](event)
+  local code, converted_data = self:build_group_macro_value(data, index_name, format, regex)
+
+  if not code then
+    self.sc_logger:error("[sc_macros:get_group_macro]: couldn't convert data for group type: " .. tostring(group_type)
+      .. ". Desired format: " .. tostring(format) .. ". Filtering using regex: " .. tostring(regex))
+    return false 
+  end
+
+  return converted_data, format
+end
+
+--- get_hg_macro: retrieve hostgroup information and make it available as a macro
+-- @param event (table) all the event information
+-- @return hostgroups (table) all the hostgroups linked to the event
+-- @return index_name (string) the name of the index that is linked to the name of the hostgroup
+function ScMacros:get_hg_macro(event)
+  return event.cache.hostgroups, "group_name"
+end
+
+--- get_sg_macro: retrieve servicegroup information and make it available as a macro
+-- @param event (table) all the event information
+-- @return servicegroups (table) all the servicegroups linked to the event
+-- @return index_name (string) the name of the index that is linked to the name of the servicegroup
+function ScMacros:get_sg_macro(event)
+  return event.cache.servicegroups, "group_name"
+end
+
+--- get_bv_macro: retrieve BV information and make it available as a macro
+-- @param event (table) all the event information
+-- @return bvs (table) all the BVS linked to the event
+-- @return index_name (string) the name of the index that is linked to the name of the BV
+function ScMacros:get_bv_macro(event)
+  return event.cache.bvs, "bv_name"
+end
+
+--- build_group_macro_value: build the value that must replace the macro (it will also put it in the desired format)
+-- @param data (table) the data from the group (hg, sg or bvs)
+-- @param index_name (string) the name of the index at which we will find the relevant data (most of the time, the name of hg, sg or bv)
+-- @param format (string) the output format we want (can be table or inline)
+-- @param regex (string) the regex that is going to be used to filter unwanted hg, sg or bv (use wildcard .* to accepte everything)
+-- @return boolean (boolean) false if asked format is unknown, true otherwise
+-- @return macro_value (string|table) the value that will replace the macro (the type of returned value depends on the asked format)
+function ScMacros:build_group_macro_value(data, index_name, format, regex)
+  local result = {}
+  for _, group_info in pairs(data) do
+    if string.match(group_info[index_name], regex) then
+      table.insert(result, group_info[index_name])
+    end
+  end
+  
+  if not self.group_macro_format[format] then
+    self.sc_logger:error("[sc_macros:build_group_macro_value]: unknown format for group macro. Format provided: " .. tostring(format))
+    return false
+  end
+
+  return true, self.group_macro_format[format](result)
+end
+
+--- group_macro_format_table: transform the value behind the macro into a table
+-- @param data (table) the values linked to the macro
+-- @return data (table) the values linked to the macro stored inside a table
+function ScMacros:group_macro_format_table(data)
+  -- data is already a table, nothing to do
+  return data
+end
+
+--- group_macro_format_inline: transform the value behind the macro into a single line string separated using a coma
+-- @param data (table) the values linked to the macro
+-- @return result (string) the values linked to the macro stored inside a coma separated string
+function ScMacros:group_macro_format_inline(data)
+  local result = ""
+
+  for _, value in pairs(data) do
+    if result == "" then
+      result = value
+    else
+      result = result .. "," .. value
+    end
+  end
+
+  return result
 end
 
 --- convert_centreon_macro: replace a centreon macro with its value

--- a/modules/centreon-stream-connectors-lib/sc_macros.lua
+++ b/modules/centreon-stream-connectors-lib/sc_macros.lua
@@ -534,7 +534,6 @@ end
 -- @return number (number) a number based on the provided string
 function ScMacros:transform_number(macro_value)
   local result = tonumber(macro_value)
-  self.sc_logger:debug("[TANGUY:TANGUY]: to number " .. self.sc_common:dumper(result))
   return result
 end
 

--- a/modules/docs/README.md
+++ b/modules/docs/README.md
@@ -146,7 +146,7 @@
 | get_bv_macro              | retrieves business view information and make it available as a macro                    | [Documentation](sc_macros.md#get_bv_macro-method)             |
 | build_group_macro_value   | build the value that must replace the macro (it will also put it in the desired format) | [Documentation](sc_macros.md#build_group_macro_value-method)  |
 | group_macro_format_table  | transforms the given macro value into a table                                           | [Documentation](sc_macros.md#group_macro_format_table-method) |
-| group_macro_format_inline | method transforms the give macro value into a string with values separated using comas  | [Documentation](sc_macros.md#group_macro_format_table-method) |
+| group_macro_format_inline | method transforms the give macro value into a string with values separated using comas  | [Documentation](sc_macros.md#group_macro_format_inline-method) |
 
 ## sc_flush methods
 

--- a/modules/docs/README.md
+++ b/modules/docs/README.md
@@ -43,6 +43,7 @@
 | load_json_file                     | method loads a json file and parse it                                                       | [Documentation](sc_common.md#load_json_file-method)                     |
 | json_escape                        | escape json characters in a string                                                          | [Documentation](sc_common.md#json_escape-method)                        |
 | xml_escape                         | escape xml characters in a string                                                           | [Documentation](sc_common.md#xml_escape-method)                         |
+| lua_regex_escape                   | escape lua regex special characters in a string                                             | [Documentation](sc_common.md#lua_regex_escape-method)                   |
 | dumper                             | dump any variable for debug purpose                                                         | [Documentation](sc_common.md#dumper-method)                             |
 
 ## sc_logger methods
@@ -125,18 +126,27 @@
 
 ## sc_macros methods
 
-| Method name            | Method description                                                             | Link                                                        |
-| ---------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------------- |
-| replace_sc_macro       | replace a stream connector macro with its value                                | [Documentation](sc_macros.md#replace_sc_macro-method)       |
-| get_cache_macro        | retrieve a macro value in the cache                                            | [Documentation](sc_macros.md#get_cache_macro-method)        |
-| get_event_macro        | retrieve a macro value in the event                                            | [Documentation](sc_macros.md#get_event_macro-method)        |
-| convert_centreon_macro | replace a Centreon macro with its value                                        | [Documentation](sc_macros.md#convert_centreon_macro-method) |
-| get_centreon_macro     | transform a Centreon macro into a stream connector macro                       | [Documentation](sc_macros.md#get_centreon_macro-method)     |
-| get_transform_flag     | try to find a transformation flag in the macro name                            | [Documentation](sc_macros.md#get_transform_flag-method)     |
-| transform_date         | transform a timestamp into a human readable format                             | [Documentation](sc_macros.md#transform_date-method)         |
-| transform_short        | keep the first line of a string                                                | [Documentation](sc_macros.md#transform_short-method)        |
-| transform_type         | convert 0 or 1 into SOFT or HARD                                               | [Documentation](sc_macros.md#transform_type-method)         |
-| transform_state        | convert a status code into its matching human readable status (OK, WARNING...) | [Documentation](sc_macros.md#transform_state-method)        |
+| Method name               | Method description                                                                      | Link                                                          |
+| ------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| replace_sc_macro          | replace a stream connector macro with its value                                         | [Documentation](sc_macros.md#replace_sc_macro-method)         |
+| get_cache_macro           | retrieve a macro value in the cache                                                     | [Documentation](sc_macros.md#get_cache_macro-method)          |
+| get_event_macro           | retrieve a macro value in the event                                                     | [Documentation](sc_macros.md#get_event_macro-method)          |
+| get_group_macro           | retrieve a macro from groups (hostgroups, servicegroups, business views)                | [Documentation](sc_macros.md#get_group_macro-method)          |
+| convert_centreon_macro    | replace a Centreon macro with its value                                                 | [Documentation](sc_macros.md#convert_centreon_macro-method)   |
+| get_centreon_macro        | transform a Centreon macro into a stream connector macro                                | [Documentation](sc_macros.md#get_centreon_macro-method)       |
+| get_transform_flag        | try to find a transformation flag in the macro name                                     | [Documentation](sc_macros.md#get_transform_flag-method)       |
+| transform_date            | transform a timestamp into a human readable format                                      | [Documentation](sc_macros.md#transform_date-method)           |
+| transform_short           | keep the first line of a string                                                         | [Documentation](sc_macros.md#transform_short-method)          |
+| transform_type            | convert 0 or 1 into SOFT or HARD                                                        | [Documentation](sc_macros.md#transform_type-method)           |
+| transform_state           | convert a status code into its matching human readable status (OK, WARNING...)          | [Documentation](sc_macros.md#transform_state-method)          |
+| transform_number          | convert a string into a number                                                          | [Documentation](sc_macros.md#transform_number-method)         |
+| transform_string          | convert anything into a string                                                          | [Documentation](sc_macros.md#transform_string-method)         |
+| get_hg_macro              | retrieves hostgroup information and make it available as a macro                        | [Documentation](sc_macros.md#get_hg_macro-method)             |
+| get_sg_macro              | retrieves servicegroup information and make it available as a macro                     | [Documentation](sc_macros.md#get_sg_macro-method)             |
+| get_bv_macro              | retrieves business view information and make it available as a macro                    | [Documentation](sc_macros.md#get_bv_macro-method)             |
+| build_group_macro_value   | build the value that must replace the macro (it will also put it in the desired format) | [Documentation](sc_macros.md#build_group_macro_value-method)  |
+| group_macro_format_table  | transforms the given macro value into a table                                           | [Documentation](sc_macros.md#group_macro_format_table-method) |
+| group_macro_format_inline | method transforms the give macro value into a string with values separated using comas  | [Documentation](sc_macros.md#group_macro_format_table-method) |
 
 ## sc_flush methods
 

--- a/modules/docs/README.md
+++ b/modules/docs/README.md
@@ -45,6 +45,7 @@
 | xml_escape                         | escape xml characters in a string                                                           | [Documentation](sc_common.md#xml_escape-method)                         |
 | lua_regex_escape                   | escape lua regex special characters in a string                                             | [Documentation](sc_common.md#lua_regex_escape-method)                   |
 | dumper                             | dump any variable for debug purpose                                                         | [Documentation](sc_common.md#dumper-method)                             |
+| trim                               | trim spaces (or provided character) at the beginning and the end of a string                | [Documentation](sc_common.md#trim-method)                               |
 
 ## sc_logger methods
 
@@ -126,27 +127,28 @@
 
 ## sc_macros methods
 
-| Method name               | Method description                                                                      | Link                                                          |
-| ------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| replace_sc_macro          | replace a stream connector macro with its value                                         | [Documentation](sc_macros.md#replace_sc_macro-method)         |
-| get_cache_macro           | retrieve a macro value in the cache                                                     | [Documentation](sc_macros.md#get_cache_macro-method)          |
-| get_event_macro           | retrieve a macro value in the event                                                     | [Documentation](sc_macros.md#get_event_macro-method)          |
-| get_group_macro           | retrieve a macro from groups (hostgroups, servicegroups, business views)                | [Documentation](sc_macros.md#get_group_macro-method)          |
-| convert_centreon_macro    | replace a Centreon macro with its value                                                 | [Documentation](sc_macros.md#convert_centreon_macro-method)   |
-| get_centreon_macro        | transform a Centreon macro into a stream connector macro                                | [Documentation](sc_macros.md#get_centreon_macro-method)       |
-| get_transform_flag        | try to find a transformation flag in the macro name                                     | [Documentation](sc_macros.md#get_transform_flag-method)       |
-| transform_date            | transform a timestamp into a human readable format                                      | [Documentation](sc_macros.md#transform_date-method)           |
-| transform_short           | keep the first line of a string                                                         | [Documentation](sc_macros.md#transform_short-method)          |
-| transform_type            | convert 0 or 1 into SOFT or HARD                                                        | [Documentation](sc_macros.md#transform_type-method)           |
-| transform_state           | convert a status code into its matching human readable status (OK, WARNING...)          | [Documentation](sc_macros.md#transform_state-method)          |
-| transform_number          | convert a string into a number                                                          | [Documentation](sc_macros.md#transform_number-method)         |
-| transform_string          | convert anything into a string                                                          | [Documentation](sc_macros.md#transform_string-method)         |
-| get_hg_macro              | retrieves hostgroup information and make it available as a macro                        | [Documentation](sc_macros.md#get_hg_macro-method)             |
-| get_sg_macro              | retrieves servicegroup information and make it available as a macro                     | [Documentation](sc_macros.md#get_sg_macro-method)             |
-| get_bv_macro              | retrieves business view information and make it available as a macro                    | [Documentation](sc_macros.md#get_bv_macro-method)             |
-| build_group_macro_value   | build the value that must replace the macro (it will also put it in the desired format) | [Documentation](sc_macros.md#build_group_macro_value-method)  |
-| group_macro_format_table  | transforms the given macro value into a table                                           | [Documentation](sc_macros.md#group_macro_format_table-method) |
-| group_macro_format_inline | method transforms the give macro value into a string with values separated using comas  | [Documentation](sc_macros.md#group_macro_format_inline-method) |
+| Method name                                      | Method description                                                                      | Link                                                                                  |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| replace_sc_macro                                 | replace a stream connector macro with its value                                         | [Documentation](sc_macros.md#replace_sc_macro-method)                                 |
+| get_cache_macro                                  | retrieve a macro value in the cache                                                     | [Documentation](sc_macros.md#get_cache_macro-method)                                  |
+| get_event_macro                                  | retrieve a macro value in the event                                                     | [Documentation](sc_macros.md#get_event_macro-method)                                  |
+| get_group_macro                                  | retrieve a macro from groups (hostgroups, servicegroups, business views)                | [Documentation](sc_macros.md#get_group_macro-method)                                  |
+| convert_centreon_macro                           | replace a Centreon macro with its value                                                 | [Documentation](sc_macros.md#convert_centreon_macro-method)                           |
+| get_centreon_macro                               | transform a Centreon macro into a stream connector macro                                | [Documentation](sc_macros.md#get_centreon_macro-method)                               |
+| get_transform_flag                               | try to find a transformation flag in the macro name                                     | [Documentation](sc_macros.md#get_transform_flag-method)                               |
+| transform_date                                   | transform a timestamp into a human readable format                                      | [Documentation](sc_macros.md#transform_date-method)                                   |
+| transform_short                                  | keep the first line of a string                                                         | [Documentation](sc_macros.md#transform_short-method)                                  |
+| transform_type                                   | convert 0 or 1 into SOFT or HARD                                                        | [Documentation](sc_macros.md#transform_type-method)                                   |
+| transform_state                                  | convert a status code into its matching human readable status (OK, WARNING...)          | [Documentation](sc_macros.md#transform_state-method)                                  |
+| transform_number                                 | convert a string into a number                                                          | [Documentation](sc_macros.md#transform_number-method)                                 |
+| transform_string                                 | convert anything into a string                                                          | [Documentation](sc_macros.md#transform_string-method)                                 |
+| get_hg_macro                                     | retrieves hostgroup information and make it available as a macro                        | [Documentation](sc_macros.md#get_hg_macro-method)                                     |
+| get_sg_macro                                     | retrieves servicegroup information and make it available as a macro                     | [Documentation](sc_macros.md#get_sg_macro-method)                                     |
+| get_bv_macro                                     | retrieves business view information and make it available as a macro                    | [Documentation](sc_macros.md#get_bv_macro-method)                                     |
+| build_group_macro_value                          | build the value that must replace the macro (it will also put it in the desired format) | [Documentation](sc_macros.md#build_group_macro_value-method)                          |
+| group_macro_format_table                         | transforms the given macro value into a table                                           | [Documentation](sc_macros.md#group_macro_format_table-method)                         |
+| group_macro_format_inline                        | transforms the give macro value into a string with values separated using comas         | [Documentation](sc_macros.md#group_macro_format_inline-method)                        |
+| build_converted_string_for_cache_and_event_macro | replace event or cache macro in a string that may contain them                          | [Documentation](sc_macros.md#build_converted_string_for_cache_and_event_macro-method) |
 
 ## sc_flush methods
 

--- a/modules/docs/sc_common.md
+++ b/modules/docs/sc_common.md
@@ -57,6 +57,10 @@
     - [dumper: parameters](#dumper-parameters)
     - [dumper: returns](#dumper-returns)
     - [dumper: example](#dumper-example)
+  - [trim method](#trim-method)
+    - [trim: parameters](#trim-parameters)
+    - [trim: returns](#trim-returns)
+    - [trim: example](#trim-example)
 
 ## Introduction
 
@@ -466,7 +470,7 @@ local result = test_common:lua_regex_escape(string)
 
 ## dumper method
 
-The **dumper** dump variables for debug purpose
+The **dumper** method dumps variables for debug purpose
 
 ### dumper: parameters
 
@@ -503,4 +507,35 @@ local result = "best city info: " .. test_common:dumper(best_city)
                 [number] lon: -0.4964242
                 [number] lat: 43.89446
 ]]--
+```
+
+## trim method
+
+The **trim** methods remove spaces (or the specified character) at the beginning and the end of a string
+
+### trim: parameters
+
+| parameter                                                                         | type   | optional | default value |
+| --------------------------------------------------------------------------------- | ------ | -------- | ------------- |
+| the string that must be trimmed                                                   | string | no       |               |
+| the character the must be removed (if not provided, will remove space characters) | string | yes      |               |
+
+### trim: returns
+
+| return              | type   | always | condition |
+| ------------------- | ------ | ------ | --------- |
+| the trimmed variable | string | yes    |           |
+
+### trim: example
+
+```lua
+local string = "                 I'm a space maaaaan        "
+
+local result = test_common:trim(string)
+--> result is: "I'm a space maaaaan"
+
+local string = ";;;;;;I'm no longer a space maaaaan;;;;;;;;;;;;;;"
+
+local result = test_common:trim(string, ";")
+--> result is: "I'm no longer a space maaaaan"
 ```

--- a/modules/docs/sc_common.md
+++ b/modules/docs/sc_common.md
@@ -49,6 +49,10 @@
     - [xml_escape: parameters](#xml_escape-parameters)
     - [xml_escape: returns](#xml_escape-returns)
     - [xml_escape: example](#xml_escape-example)
+  - [lua_regex_escape method](#lua_regex_escape-method)
+    - [lua_regex_escape: parameters](#lua_regex_escape-parameters)
+    - [lua_regex_escape: returns](#lua_regex_escape-returns)
+    - [lua_regex_escape: example](#lua_regex_escape-example)
   - [dumper method](#dumper-method)
     - [dumper: parameters](#dumper-parameters)
     - [dumper: returns](#dumper-returns)
@@ -432,6 +436,32 @@ local string = 'string with " and < and >'
 
 local result = test_common:xml_escape(string)
 --> result is 'string with &quot; and &lt; and &gt;'
+```
+
+## lua_regex_escape method
+
+The **lua_regex_escape** method escape lua regex special characters.
+
+### lua_regex_escape: parameters
+
+| parameter                     | type   | optional | default value |
+| ----------------------------- | ------ | -------- | ------------- |
+| a string that must be escaped | string | no       |               |
+
+### lua_regex_escape: returns
+
+| return                                                                 | type                             | always | condition |
+| ---------------------------------------------------------------------- | -------------------------------- | ------ | --------- |
+| an escaped string (or the raw parameter if it was nil or not a string) | string (or input parameter type) | yes    |           |
+
+### lua_regex_escape: example
+
+```lua
+local string = 'string with % and . and *'
+--> string is 'string with % and . and *'
+
+local result = test_common:lua_regex_escape(string)
+--> result is 'string with %% and %. and %*'
 ```
 
 ## dumper method

--- a/modules/docs/sc_macros.md
+++ b/modules/docs/sc_macros.md
@@ -90,6 +90,10 @@
     - [group_macro_format_inline: parameters](#group_macro_format_inline-parameters)
     - [group_macro_format_inline: returns](#group_macro_format_inline-returns)
     - [group_macro_format_inline: example](#group_macro_format_inline-example)
+  - [build_converted_string_for_cache_and_event_macro method](#build_converted_string_for_cache_and_event_macro-method)
+    - [build_converted_string_for_cache_and_event_macro: parameters](#build_converted_string_for_cache_and_event_macro-parameters)
+    - [build_converted_string_for_cache_and_event_macro: returns](#build_converted_string_for_cache_and_event_macro-returns)
+    - [build_converted_string_for_cache_and_event_macro: example](#build_converted_string_for_cache_and_event_macro-example)
 
 ## Introduction
 
@@ -1025,8 +1029,8 @@ The **group_macro_format_inline** method transforms the give macro value into a 
 
 ### group_macro_format_inline: returns
 
-| return                     | type  | always | condition |
-| -------------------------- | ----- | ------ | --------- |
+| return                      | type   | always | condition |
+| --------------------------- | ------ | ------ | --------- |
 | the macro value as a string | string | yes    |           |
 
 ### group_macro_format_inline: example
@@ -1039,4 +1043,33 @@ local macro_value = {
 
 local result = test_macros:group_macro_format_inline(macro_value)
 --> result is: "bv2,bv3"
+```
+
+## build_converted_string_for_cache_and_event_macro method
+
+The **build_converted_string_for_cache_and_event_macro** method replace a cache or event macro in a string that may contain those macros
+
+### build_converted_string_for_cache_and_event_macro: parameters
+
+| parameter                          | type   | optional | default value |
+| ---------------------------------- | ------ | -------- | ------------- |
+| the macro value                    | any    | no       |               |
+| the macro name                     | string | no       |               |
+| the string that may contain macros | string | no       |               |
+
+### build_converted_string_for_cache_and_event_macro: returns
+
+| return                              | type   | always | condition |
+| ----------------------------------- | ------ | ------ | --------- |
+| the string with the macro converted | string | yes    |           |
+
+### build_converted_string_for_cache_and_event_macro: example
+
+```lua
+local string_with_macros = "my cache macro {cache.host.name}
+local macro_name = "{cache.host.name}"
+local macro_value = "Arcadia"
+
+local result = test_macros:build_converted_string_for_cache_and_event_macro(macro_value, macro_name, string_with_macros)
+--> result is: "my cache macro Arcadia"
 ```

--- a/modules/docs/sc_macros.md
+++ b/modules/docs/sc_macros.md
@@ -981,7 +981,7 @@ code, result = test_macros:build_group_macro_value(group_data, index_name, forma
 
 ## group_macro_format_table method
 
-The **group_macro_format_table** method transforms the give macro value into a table (does nothing as is)
+The **group_macro_format_table** method transforms the given macro value into a table (does nothing as is)
 
 ### group_macro_format_table: parameters
 

--- a/modules/docs/sc_macros.md
+++ b/modules/docs/sc_macros.md
@@ -5,6 +5,11 @@
   - [Stream connectors macro explanation](#stream-connectors-macro-explanation)
     - [Event macros](#event-macros)
     - [Cache macros](#cache-macros)
+    - [Group macros](#group-macros)
+      - [group type](#group-type)
+      - [output format](#output-format)
+      - [regex filter](#regex-filter)
+      - [examples](#examples)
     - [Transformation flags](#transformation-flags)
   - [Module initialization](#module-initialization)
     - [Module constructor](#module-constructor)
@@ -21,6 +26,10 @@
     - [get_event_macro: parameters](#get_event_macro-parameters)
     - [get_event_macro: returns](#get_event_macro-returns)
     - [get_event_macro: example](#get_event_macro-example)
+  - [get_group_macro method](#get_group_macro-method)
+    - [get_group_macro: parameters](#get_group_macro-parameters)
+    - [get_group_macro: returns](#get_group_macro-returns)
+    - [get_group_macro: example](#get_group_macro-example)
   - [convert_centreon_macro method](#convert_centreon_macro-method)
     - [convert_centreon_macro: parameters](#convert_centreon_macro-parameters)
     - [convert_centreon_macro: returns](#convert_centreon_macro-returns)
@@ -49,6 +58,38 @@
     - [transform_state: parameters](#transform_state-parameters)
     - [transform_state: returns](#transform_state-returns)
     - [transform_state: example](#transform_state-example)
+  - [transform_number method](#transform_number-method)
+    - [transform_number: parameters](#transform_number-parameters)
+    - [transform_number: returns](#transform_number-returns)
+    - [transform_number: example](#transform_number-example)
+  - [transform_string method](#transform_string-method)
+    - [transform_string: parameters](#transform_string-parameters)
+    - [transform_string: returns](#transform_string-returns)
+    - [transform_string: example](#transform_string-example)
+  - [get_hg_macro method](#get_hg_macro-method)
+    - [get_hg_macro: parameters](#get_hg_macro-parameters)
+    - [get_hg_macro: returns](#get_hg_macro-returns)
+    - [get_hg_macro: example](#get_hg_macro-example)
+  - [get_sg_macro method](#get_sg_macro-method)
+    - [get_sg_macro: parameters](#get_sg_macro-parameters)
+    - [get_sg_macro: returns](#get_sg_macro-returns)
+    - [get_sg_macro: example](#get_sg_macro-example)
+  - [get_bv_macro method](#get_bv_macro-method)
+    - [get_bv_macro: parameters](#get_bv_macro-parameters)
+    - [get_bv_macro: returns](#get_bv_macro-returns)
+    - [get_bv_macro: example](#get_bv_macro-example)
+  - [build_group_macro_value method](#build_group_macro_value-method)
+    - [build_group_macro_value: parameters](#build_group_macro_value-parameters)
+    - [build_group_macro_value: returns](#build_group_macro_value-returns)
+    - [build_group_macro_value: example](#build_group_macro_value-example)
+  - [group_macro_format_table method](#group_macro_format_table-method)
+    - [group_macro_format_table: parameters](#group_macro_format_table-parameters)
+    - [group_macro_format_table: returns](#group_macro_format_table-returns)
+    - [group_macro_format_table: example](#group_macro_format_table-example)
+  - [group_macro_format_inline method](#group_macro_format_inline-method)
+    - [group_macro_format_inline: parameters](#group_macro_format_inline-parameters)
+    - [group_macro_format_inline: returns](#group_macro_format_inline-returns)
+    - [group_macro_format_inline: example](#group_macro_format_inline-example)
 
 ## Introduction
 
@@ -56,7 +97,13 @@ The sc_macros module provides methods to handle a stream connector oriented macr
 
 ## Stream connectors macro explanation
 
-There are two kind of stream connectors macro, the **event macros** and the **cache macros**. The first type refers to data that are accessible right from the event. The second type refers to data that needs to be retrieved from the broker cache.
+There are three kind of stream connectors macro:
+
+- **event macros**
+- **cache macros**
+- **group macros**
+
+The first type refers to data that are accessible right from the event. The second type refers to data that needs to be retrieved from the broker cache. And the last type refers to three kind of group object in Centreon (hostgroups, servicegroups and Business views)
 
 ### Event macros
 
@@ -76,16 +123,13 @@ This means that it is possible to use the following macros
 
 This one is a bit more complicated. The purpose is to retrieve information from the event cache using a macro. If you rely on the centreon-stream-connectors-lib to fill the cache, here is what you need to know.
 
-There are 8 kind of cache
+There are 5 kind of cache
 
 - host cache (for any event that is linked to a host, which means any event but BA events)
 - service cache (for any event that is linked to a service)
-- poller cache (only generated if you filter your events on a poller)
-- severity cache (only generated if you filter your events on a severity)
-- hostgroups cache (only generated if you filter your events on a hostgroup)
-- servicegroups cache (only generated if you filter your events on a servicegroup)
+- poller cache (for any event that is linked to a poller, which means any event but BA events)
+- severity cache  (for any event that is linked to a host, which means any event but BA events)
 - ba cache (only for a ba_status event)
-- bvs cache (only generated if you filter your BA events on a BV)
 
 For example, if we want to retrieve the description of a service in the cache (because the description is not provided in the event data). We will use `{cache.service.description}`.
 
@@ -99,6 +143,68 @@ This means that it is possible to use the following macros
 "{cache.service.last_time_critical}" -- will be replaced by the service last_time_critical timestamp
 ```
 
+cache values for hosts: [list](sc_broker.md#get_host_all_infos-example)
+cache values for services: [list](sc_broker.md#get_services_all_infos-example)
+cache values for BAs: [list](sc_broker.md#get_ba_infos-example)
+cache values for pollers:
+  
+- {cache.instance.name}
+- {cache.instance.id}
+
+cache values for severities:
+
+- {cache.severity.service}
+- {cache.severity.host}
+
+### Group macros
+
+Group macros are a very special kind of macros that allows you to retrieve the hostgroups, services groups or BVs that are linked to your host/service/BA. The syntax goes as follow: `{groups(<group_type>,<output_format>,<regex_filter>)}`
+
+It means that when using a group macro, you need to specify which kind of group you want, its output format and the filter you are going to use.
+
+#### group type
+
+When using a group macro, you need to set a group type. You have three possibilities
+
+- hg (to retrieve hostgroups)
+- sg (to retrieve servicegroups)
+- bv (to retrives business views)
+
+#### output format
+
+When using a group, you need to set an output format. You have two possibilities
+
+- table (each found group is going to be stored in a table structure)
+- inline (each found group is going to be stored in a string and each value will be separated using a `,`)
+
+#### regex filter
+
+When using a group, you need to set a regex filter. You accept everything using `.*` or you can accept groups that will only have alpha numerical characters in their name with `^%w+$`.
+
+[More information about regex in lua](https://www.lua.org/pil/20.2.html)
+
+#### examples
+
+for a service linked to:
+
+| hostgroups | servicegroups  |
+| ---------- | -------------- |
+| HG_1       | FOO_the-first  |
+| HG_2       | FOO_the-second |
+| HG_3       | another_sg     |
+
+get all hostgroups in a table format:
+
+| macro                   | result                     |
+| ----------------------- | -------------------------- |
+| `{groups(hg,table,.*)}` | `["HG_1", "HG_2", "HG_3"]` |
+
+get all servicegroups that start with "FOO" in an inline format: `{groups}
+
+| macro                        | result                           |
+| ---------------------------- | -------------------------------- |
+| `{groups(sg,inline,^FOO.*)}` | `"FOO_the-first,FOO_the-second"` |
+
 ### Transformation flags
 
 You can use transformation flags on stream connectors macros. Those flags purpose is to convert the given value to something more appropriate. For example, you can convert a timestamp to a human readable date.
@@ -111,6 +217,8 @@ Here is the list of all available flags
 | _sctype   | convert a state type number to its human value                                                                              | 0                                            | SOFT                   |
 | _scstate  | convert a state to its human value                                                                                          | 2                                            | WARNING (for a servie) |
 | _scshort  | only retrieve the first line of a string (mostly use to get the output instead of the long output of a service for exemple) | "my output\n this is part of the longoutput" | "my output"            |
+| _scnumber | convert a string to a number                                                                                                | "1"                                          | 1                      |
+| _scstring | convert anything to a string                                                                                                | false                                        | "false"                |
 
 The **_scdate** is a bit specific because you can change the date format using the [**timestamp_conversion_format parameter**](sc_param.md#default-parameters)
 
@@ -121,7 +229,9 @@ With all that information in mind, we can use the following macros
 "{cache.service.last_time_critical_scdate}" -- will be replaced by the service last_time_critical converted in a human readable date format
 "{state_type_sctype}" -- will be replaced by the service state_type in a human readable format (SOFT or HARD)
 "{state_scstate}" -- will be replaced by the servie state in a human readable format (OK, WARNING, CRITICAL or UNKNOWN)
-"{output_short}" -- will be replaced by the first line of the service output
+"{output_scshort}" -- will be replaced by the first line of the service output
+"{cache.severity.service_scnumber}" -- will be replaced by 1 instead of "1"
+"{acknowledged_scstring}" -- will be replaced by "false" instead of false 
 ```
 
 ## Module initialization
@@ -294,6 +404,68 @@ local result = test_macros:get_event_macro(macro, event)
 macro = "{cache.host.name}"
 result = test_macros:get_event_macro(macro, event)
 --> result is false, cache.host.name is in the cache table, not directly in the event table
+```
+
+## get_group_macro method
+
+The **get_group_macro** method replaces a stream connector group macro by its value.
+
+head over the following chapters for more information
+
+- [Group macros](#group-macros)
+
+### get_group_macro: parameters
+
+| parameter      | type   | optional | default value |
+| -------------- | ------ | -------- | ------------- |
+| the macro name | string | no       |               |
+| the event      | table  | no       |               |
+
+### get_group_macro: returns
+
+| return             | type                        | always | condition                                  |
+| ------------------ | --------------------------- | ------ | ------------------------------------------ |
+| false              | boolean                     | no     | if the macro is not a group macro          |
+| value of the macro | boolean or string or number | no     | the value that has been found in the event |
+
+### get_group_macro: example
+
+```lua
+local macro = "{groups(hg,table,^%w+$)}"
+local event = {
+  host_id = 2712,
+  state_type = 1,
+  state = 0
+  cache = {
+    hostgroups = {
+      [1] = {
+        group_id = 27,
+        group_name = "hg_1"
+      },
+      [2] = {
+        group_id = 12,
+        group_name = "hg2"
+      },
+      [3] = {
+        group_id = 1991
+        group_name = "hg3"
+      }
+    }
+  }
+}
+
+local result = test_macros:get_group_macro(macro, event)
+--> result is
+--[[
+  {
+    [1] = "hg2",
+    [2] = "hg3"
+  }
+]] 
+
+macro = "{groups(foo,bar,.*)}"
+result = test_macros:get_group_macro(macro, event)
+--> result is false, foo is not a valid group type and bar is not a valid format type
 ```
 
 ## convert_centreon_macro method
@@ -516,4 +688,355 @@ event = {
 
 result = test_macros:transform_state(state, event)
 --> result is "DOWN" because it is a service (category 1 = neb, element 14 = host_status event)
+```
+
+## transform_number method
+
+The **transform_number** method transforms a string value into a number
+
+### transform_number: parameters
+
+| parameter | type   | optional | default value |
+| --------- | ------ | -------- | ------------- |
+| a string  | string | no       |               |
+
+### transform_number: returns
+
+| return   | type   | always | condition |
+| -------- | ------ | ------ | --------- |
+| a number | number | yes    |           |
+
+### transform_number: example
+
+```lua
+local string_number = "0"
+
+local result = test_macros:transform_number(string_number)
+--> result is 0
+```
+
+## transform_string method
+
+The **transform_string** method transforms any value into a string
+
+### transform_string: parameters
+
+| parameter | type | optional | default value |
+| --------- | ---- | -------- | ------------- |
+| anything  | any  | no       |               |
+
+### transform_string: returns
+
+| return   | type   | always | condition |
+| -------- | ------ | ------ | --------- |
+| a string | string | yes    |           |
+
+### transform_string: example
+
+```lua
+local boolean = false
+
+local result = test_macros:transform_string(boolean)
+--> result is "false"
+```
+
+## get_hg_macro method
+
+The **get_hg_macro** method retrieves hostgroup information and make it available as a macro
+
+### get_hg_macro: parameters
+
+| parameter | type  | optional | default value |
+| --------- | ----- | -------- | ------------- |
+| the event | table | no       |               |
+
+### get_hg_macro: returns
+
+| return                                                  | type   | always | condition |
+| ------------------------------------------------------- | ------ | ------ | --------- |
+| all hostgroups                                          | table  | yes    |           |
+| the name of the index that is linked to hostgroups name | string | yes    |           |
+
+### get_hg_macro: example
+
+```lua
+local event = {
+  host_id = 2712,
+  state_type = 1,
+  state = 0
+  cache = {
+    hostgroups = {
+      [1] = {
+        group_id = 27,
+        group_name = "hg_1"
+      },
+      [2] = {
+        group_id = 12,
+        group_name = "hg2"
+      },
+      [3] = {
+        group_id = 1991
+        group_name = "hg3"
+      }
+    }
+  }
+}
+
+local hostgroups, index_name = test_macros:get_hg_macro(event)
+--> hostgroups is:
+--[[
+  hostgroups = {
+      [1] = {
+        group_id = 27,
+        group_name = "hg_1"
+      },
+      [2] = {
+        group_id = 12,
+        group_name = "hg2"
+      },
+      [3] = {
+        group_id = 1991
+        group_name = "hg3"
+      }
+    }
+]] 
+--> index_name is: group_name
+```
+
+## get_sg_macro method
+
+The **get_sg_macro** method retrieves servicegroup information and make it available as a macro
+
+### get_sg_macro: parameters
+
+| parameter | type  | optional | default value |
+| --------- | ----- | -------- | ------------- |
+| the event | table | no       |               |
+
+### get_sg_macro: returns
+
+| return                                                     | type   | always | condition |
+| ---------------------------------------------------------- | ------ | ------ | --------- |
+| all servicegroups                                          | table  | yes    |           |
+| the name of the index that is linked to servicegroups name | string | yes    |           |
+
+### get_sg_macro: example
+
+```lua
+local event = {
+  host_id = 2712,
+  state_type = 1,
+  state = 0
+  cache = {
+    hostgroups = {
+      [1] = {
+        group_id = 27,
+        group_name = "sg_1"
+      },
+      [2] = {
+        group_id = 12,
+        group_name = "sg2"
+      },
+      [3] = {
+        group_id = 1991
+        group_name = "sg3"
+      }
+    }
+  }
+}
+
+local servicegroups, index_name = test_macros:get_sg_macro(event)
+--> servicegroups is:
+--[[
+  servicegroups = {
+      [1] = {
+        group_id = 27,
+        group_name = "sg_1"
+      },
+      [2] = {
+        group_id = 12,
+        group_name = "sg2"
+      },
+      [3] = {
+        group_id = 1991
+        group_name = "sg3"
+      }
+    }
+]] 
+--> index_name is: group_name
+```
+
+## get_bv_macro method
+
+The **get_bv_macro** method retrieves business views information and make it available as a macro
+
+### get_bv_macro: parameters
+
+| parameter | type  | optional | default value |
+| --------- | ----- | -------- | ------------- |
+| the event | table | no       |               |
+
+### get_bv_macro: returns
+
+| return                                                      | type   | always | condition |
+| ----------------------------------------------------------- | ------ | ------ | --------- |
+| all business views                                          | table  | yes    |           |
+| the name of the index that is linked to business views name | string | yes    |           |
+
+### get_bv_macro: example
+
+```lua
+local event = {
+  ba_id = 2712,
+  state = 0
+  cache = {
+    bvs = {
+      [1] = {
+        bv_id = 27,
+        bv_name = "bv_1"
+      },
+      [2] = {
+        bv_id = 12,
+        bv_name = "bv2"
+      },
+      [3] = {
+        bv_id = 1991
+        bv_name = "bv3"
+      }
+    }
+  }
+}
+
+local bvs, index_name = test_macros:get_bv_macro(event)
+--> bvs is:
+--[[
+  bvs = {
+      [1] = {
+        bv_id = 27,
+        bv_name = "bv_1"
+      },
+      [2] = {
+        bv_id = 12,
+        bv_name = "bv2"
+      },
+      [3] = {
+        bv_id = 1991
+        bv_name = "bv3"
+      }
+    }
+]] 
+--> index_name is: bv_name
+```
+
+## build_group_macro_value method
+
+The **build_group_macro_value** method builds the value that must replace the macro (it will also put it in the desired format)
+
+### build_group_macro_value: parameters
+
+| parameter                                                | type   | optional | default value |
+| -------------------------------------------------------- | ------ | -------- | ------------- |
+| the group data                                           | table  | no       |               |
+| the name of the index where the group name will be found | string | no       |               |
+| the format in which the result will be built             | string | no       |               |
+| the regex that will filter found groups                  | string | no       |               |
+
+### build_group_macro_value: returns
+
+| return                              | type            | always | condition                           |
+| ----------------------------------- | --------------- | ------ | ----------------------------------- |
+| boolean                             | boolean         | yes    |                                     |
+| the macro value in the right format | string or table | no     | only if the desired format is valid |
+
+### build_group_macro_value: example
+
+```lua
+local group_data = {
+      [1] = {
+        bv_id = 27,
+        bv_name = "bv_1"
+      },
+      [2] = {
+        bv_id = 12,
+        bv_name = "bv2"
+      },
+      [3] = {
+        bv_id = 1991
+        bv_name = "bv3"
+      }
+    }
+local index_name = "bv_name"
+local format = "inline"
+local regex = "^%w+$"
+
+local code, result = test_macros:build_group_macro_value(group_data, index_name, format, regex)
+--> code is: true
+--> result is: "bv2,bv3"
+
+format = "bad_format"
+code, result = test_macros:build_group_macro_value(group_data, index_name, format, regex)
+--> code is: false
+--> result is: nil
+```
+
+## group_macro_format_table method
+
+The **group_macro_format_table** method transforms the give macro value into a table (does nothing as is)
+
+### group_macro_format_table: parameters
+
+| parameter       | type  | optional | default value |
+| --------------- | ----- | -------- | ------------- |
+| the macro value | table | no       |               |
+
+### group_macro_format_table: returns
+
+| return                     | type  | always | condition |
+| -------------------------- | ----- | ------ | --------- |
+| the macro value as a table | table | yes    |           |
+
+### group_macro_format_table: example
+
+```lua
+local macro_value = {
+  [1] = "bv2",
+  [2] = "bv3"
+}
+
+local result = test_macros:group_macro_format_table(macro_value)
+--> result is: 
+--[[
+  result = {
+    [1] = "bv2",
+    [2] = "bv3"
+  }
+]]--
+```
+
+## group_macro_format_inline method
+
+The **group_macro_format_inline** method transforms the give macro value into a string with values separated using comas
+
+### group_macro_format_inline: parameters
+
+| parameter       | type  | optional | default value |
+| --------------- | ----- | -------- | ------------- |
+| the macro value | table | no       |               |
+
+### group_macro_format_inline: returns
+
+| return                     | type  | always | condition |
+| -------------------------- | ----- | ------ | --------- |
+| the macro value as a string | string | yes    |           |
+
+### group_macro_format_inline: example
+
+```lua
+local macro_value = {
+  [1] = "bv2",
+  [2] = "bv3"
+}
+
+local result = test_macros:group_macro_format_inline(macro_value)
+--> result is: "bv2,bv3"
 ```


### PR DESCRIPTION
## Description

This PR grants the ability to use many more macros. 

It extends the cache macro type by adding the following macros

- {cache.severity.host}
- {cache.severity.service}
- {cache.instance.name}

It adds a new powerful system for hostgroups, servicegroups and business views. It is called the `group macro` which has its specific syntax `{groups(<type>,<format>,<regex_filter>)}`

it adds two new transformation flags 

- _scnumber
- _scstring

their purpose is to force a result to be of th selected type 

{cache.severity.service} returns a string by default and using {cache.severity.service_scnumber} 
returns the same value but as a number

**Fixes** #107 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

since it is macro related, you need to create a dedicated format file. For example 

```json
{
        "neb_service_status": {
                "SERVICE": "SERVICE",
                "name": "{cache.host.name}",
                "description": "{cache.service.description}",
                "date": "{last_check_scdate}",
                "hg": "{groups(hg,inline,^%w+$)}",
                "sg": "{groups(sg,table,.*)}",
                "service_severity": "{cache.severity.service}",
                "host_severity": "{cache.severity.host}",
                "instance": "{cache.instance.name}"
        },
        "neb_host_status": {
                "HOST": "HOST",
                "name": "{cache.host.name}",
                "date": "{last_check_scdate}",
                "hg": "{groups(hg,inline,.*)}",
                "host_severity": "{cache.severity.host}",
                "instance": "{cache.instance.name}"
        }
}
```

here is the result for a service (using the service now em stream connector): 

```json
{
  "records": [{
    "description":"Memory",
    "SERVICE":"SERVICE",
     "name":"local",
     "sg":["sg_1","sg_2"],
     "host_severity":"2",
     "hg":"toto",
     "service_severity":"1",
     "instance":"Central",
     "date":"2022-07-14 15:21:05"
  }]
}
```

This service is also linked to a hostgroup called "dza[d-za" that has been filtered out thanks to the regex 

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
