### PR TITLE
fix ack remove and dt cache and more sc options

### DIFF
--- a/modules/centreon-stream-connectors-lib/sc_event.lua
+++ b/modules/centreon-stream-connectors-lib/sc_event.lua
@@ -991,8 +991,8 @@ end
 function ScEvent:get_downtime_service_status()
   -- if cache is not filled we can't get the state of the service
   if 
-    not self.event.cache.host.last_time_ok 
-    or not self.event.cache.host.last_time_warning 
+    not self.event.cache.service.last_time_ok 
+    or not self.event.cache.service.last_time_warning 
     or not self.event.cache.service.last_time_critical 
     or not self.event.cache.service.last_time_unknown 
   then


### PR DESCRIPTION
## Description

- fix a wrong event data that was used to check if an ack has been canceled
- couldn't send downtimes in some cases because the state of the service wasn't find (some information were being retrieved from the host cache instead of service cache)
- add a new connector_name_type option that can be used to change the behavior of the connector_name that is sent so canopsis. It can be either "poller" or "custom" and it will use "poller" as a default value. When set to custom, you can use the connector_name parameter to set your own value

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)
