### PR TITLE
fix broken long output with line break

### DIFF
--- a/modules/centreon-stream-connectors-lib/sc_event.lua
+++ b/modules/centreon-stream-connectors-lib/sc_event.lua
@@ -1176,8 +1176,12 @@ end
 
 --- build_outputs: adds short_output and long_output entries in the event table. output entry will be equal to one or another depending on the use_longoutput param
 function ScEvent:build_outputs()
-  self.event.long_output = self.event.output
-  self.event.long_output = self.event.output
+  -- build long output
+  if self.event.long_output and self.event.long_output ~= "" then
+    self.event.long_output = self.event.output .. "\n" .. self.event.long_output
+  else
+    self.event.long_output = self.event.output
+  end
 
   -- no short output if there is no line break
   local short_output = string.match(self.event.output, "^(.*)\n")
@@ -1187,17 +1191,18 @@ function ScEvent:build_outputs()
     self.event.short_output = self.event.output
   end
 
-  -- use shortoutput if it exists
+  -- use short output if it exists
   if self.params.use_long_output == 0 and short_output then
     self.event.output = short_output
 
   -- replace line break if asked to and we are not already using a short output
-  elseif not short_output and  self.params.remove_line_break_in_output == 1 then
+  elseif not short_output and self.params.remove_line_break_in_output == 1 then
     self.event.output = string.gsub(self.event.output, "\n", self.params.output_line_break_replacement_character)
   end
 
   if self.params.output_size_limit ~= "" then
     self.event.output = string.sub(self.event.output, 1, self.params.output_size_limit)
+    self.event.short_output = string.sub(self.event.short_output, 1, self.params.output_size_limit)
   end
 
 end

--- a/modules/specs/3.5.x/centreon-stream-connectors-lib-3.5.1-1.rockspec
+++ b/modules/specs/3.5.x/centreon-stream-connectors-lib-3.5.1-1.rockspec
@@ -1,0 +1,39 @@
+package = "centreon-stream-connectors-lib"
+version = "3.5.1-1"
+source = {
+   url = "git+https://github.com/centreon/centreon-stream-connector-scripts",
+   tag = "3.5.1-1"
+}
+description = {
+   summary = "Centreon stream connectors lua modules",
+   detailed = [[
+      Those modules provides helpful methods to create
+      stream connectors for Centreon
+   ]],
+   license = ""
+}
+dependencies = {
+   "lua >= 5.1, < 5.4",
+   "luasocket >= 3.0rc1-2"
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["centreon-stream-connectors-lib.sc_broker"] = "modules/centreon-stream-connectors-lib/sc_broker.lua",
+     ["centreon-stream-connectors-lib.sc_common"] = "modules/centreon-stream-connectors-lib/sc_common.lua",
+     ["centreon-stream-connectors-lib.sc_event"] = "modules/centreon-stream-connectors-lib/sc_event.lua",
+     ["centreon-stream-connectors-lib.sc_logger"] = "modules/centreon-stream-connectors-lib/sc_logger.lua",
+     ["centreon-stream-connectors-lib.sc_params"] = "modules/centreon-stream-connectors-lib/sc_params.lua",
+     ["centreon-stream-connectors-lib.sc_test"] = "modules/centreon-stream-connectors-lib/sc_test.lua",
+     ["centreon-stream-connectors-lib.sc_macros"] = "modules/centreon-stream-connectors-lib/sc_macros.lua",
+     ["centreon-stream-connectors-lib.sc_flush"] = "modules/centreon-stream-connectors-lib/sc_flush.lua",
+     ["centreon-stream-connectors-lib.sc_metrics"] = "modules/centreon-stream-connectors-lib/sc_metrics.lua",
+     ["centreon-stream-connectors-lib.rdkafka.config"] = "modules/centreon-stream-connectors-lib/rdkafka/config.lua",
+     ["centreon-stream-connectors-lib.rdkafka.librdkafka"] = "modules/centreon-stream-connectors-lib/rdkafka/librdkafka.lua",
+     ["centreon-stream-connectors-lib.rdkafka.producer"] = "modules/centreon-stream-connectors-lib/rdkafka/producer.lua",
+     ["centreon-stream-connectors-lib.rdkafka.topic_config"] = "modules/centreon-stream-connectors-lib/rdkafka/topic_config.lua",
+     ["centreon-stream-connectors-lib.rdkafka.topic"] = "modules/centreon-stream-connectors-lib/rdkafka/topic.lua",
+     ["centreon-stream-connectors-lib.google.auth.oauth"] = "modules/centreon-stream-connectors-lib/google/auth/oauth.lua",
+     ["centreon-stream-connectors-lib.google.bigquery.bigquery"] = "modules/centreon-stream-connectors-lib/google/bigquery/bigquery.lua"
+   }
+}


### PR DESCRIPTION
bad use of the long output. It was removing the real long output and replacing it with the standard output. This patch also force the short output to be short when asked to