### PR TITLE
Mon 17276 fix poller filter

### DIFF
--- a/modules/centreon-stream-connectors-lib/sc_event.lua
+++ b/modules/centreon-stream-connectors-lib/sc_event.lua
@@ -1176,8 +1176,12 @@ end
 
 --- build_outputs: adds short_output and long_output entries in the event table. output entry will be equal to one or another depending on the use_longoutput param
 function ScEvent:build_outputs()
-  self.event.long_output = self.event.output
-  self.event.long_output = self.event.output
+  -- build long output
+  if self.event.long_output and self.event.long_output ~= "" then
+    self.event.long_output = self.event.output .. "\n" .. self.event.long_output
+  else
+    self.event.long_output = self.event.output
+  end
 
   -- no short output if there is no line break
   local short_output = string.match(self.event.output, "^(.*)\n")
@@ -1187,17 +1191,18 @@ function ScEvent:build_outputs()
     self.event.short_output = self.event.output
   end
 
-  -- use shortoutput if it exists
+  -- use short output if it exists
   if self.params.use_long_output == 0 and short_output then
     self.event.output = short_output
 
   -- replace line break if asked to and we are not already using a short output
-  elseif not short_output and  self.params.remove_line_break_in_output == 1 then
+  elseif not short_output and self.params.remove_line_break_in_output == 1 then
     self.event.output = string.gsub(self.event.output, "\n", self.params.output_line_break_replacement_character)
   end
 
   if self.params.output_size_limit ~= "" then
     self.event.output = string.sub(self.event.output, 1, self.params.output_size_limit)
+    self.event.short_output = string.sub(self.event.short_output, 1, self.params.output_size_limit)
   end
 
 end

--- a/modules/centreon-stream-connectors-lib/sc_event.lua
+++ b/modules/centreon-stream-connectors-lib/sc_event.lua
@@ -680,11 +680,17 @@ end
 --- is_valid_poller: check if the event is monitored from an accepted poller
 -- @return true|false (boolean)
 function ScEvent:is_valid_poller()
+  -- return false if instance id is not found in cache
+  if not self.event.cache.host.instance_id then
+    self.sc_logger:warning("[sc_event:is_valid_poller]: no instance ID found for host ID: " .. tostring(self.event.host_id))
+    return false
+  end
+
   self.event.cache.poller = self.sc_broker:get_instance(self.event.cache.host.instance_id)
 
   -- required if we want to easily have access to poller name with macros {cache.instance.name}
   self.event.cache.instance = {
-    id = self.event.cache.host.instance,
+    id = self.event.cache.host.instance_id,
     name = self.event.cache.poller
   }
   
@@ -693,11 +699,6 @@ function ScEvent:is_valid_poller()
     return true
   end
 
-  -- return false if instance id is not found in cache
-  if not self.event.cache.host.instance then
-    self.sc_logger:warning("[sc_event:is_valid_poller]: no instance ID found for host ID: " .. tostring(self.event.host_id))
-    return false
-  end
 
   -- return false if no poller found in cache
   if not self.event.cache.poller then

--- a/modules/specs/3.5.x/centreon-stream-connectors-lib-3.5.1-1.rockspec
+++ b/modules/specs/3.5.x/centreon-stream-connectors-lib-3.5.1-1.rockspec
@@ -1,0 +1,39 @@
+package = "centreon-stream-connectors-lib"
+version = "3.5.1-1"
+source = {
+   url = "git+https://github.com/centreon/centreon-stream-connector-scripts",
+   tag = "3.5.1-1"
+}
+description = {
+   summary = "Centreon stream connectors lua modules",
+   detailed = [[
+      Those modules provides helpful methods to create
+      stream connectors for Centreon
+   ]],
+   license = ""
+}
+dependencies = {
+   "lua >= 5.1, < 5.4",
+   "luasocket >= 3.0rc1-2"
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["centreon-stream-connectors-lib.sc_broker"] = "modules/centreon-stream-connectors-lib/sc_broker.lua",
+     ["centreon-stream-connectors-lib.sc_common"] = "modules/centreon-stream-connectors-lib/sc_common.lua",
+     ["centreon-stream-connectors-lib.sc_event"] = "modules/centreon-stream-connectors-lib/sc_event.lua",
+     ["centreon-stream-connectors-lib.sc_logger"] = "modules/centreon-stream-connectors-lib/sc_logger.lua",
+     ["centreon-stream-connectors-lib.sc_params"] = "modules/centreon-stream-connectors-lib/sc_params.lua",
+     ["centreon-stream-connectors-lib.sc_test"] = "modules/centreon-stream-connectors-lib/sc_test.lua",
+     ["centreon-stream-connectors-lib.sc_macros"] = "modules/centreon-stream-connectors-lib/sc_macros.lua",
+     ["centreon-stream-connectors-lib.sc_flush"] = "modules/centreon-stream-connectors-lib/sc_flush.lua",
+     ["centreon-stream-connectors-lib.sc_metrics"] = "modules/centreon-stream-connectors-lib/sc_metrics.lua",
+     ["centreon-stream-connectors-lib.rdkafka.config"] = "modules/centreon-stream-connectors-lib/rdkafka/config.lua",
+     ["centreon-stream-connectors-lib.rdkafka.librdkafka"] = "modules/centreon-stream-connectors-lib/rdkafka/librdkafka.lua",
+     ["centreon-stream-connectors-lib.rdkafka.producer"] = "modules/centreon-stream-connectors-lib/rdkafka/producer.lua",
+     ["centreon-stream-connectors-lib.rdkafka.topic_config"] = "modules/centreon-stream-connectors-lib/rdkafka/topic_config.lua",
+     ["centreon-stream-connectors-lib.rdkafka.topic"] = "modules/centreon-stream-connectors-lib/rdkafka/topic.lua",
+     ["centreon-stream-connectors-lib.google.auth.oauth"] = "modules/centreon-stream-connectors-lib/google/auth/oauth.lua",
+     ["centreon-stream-connectors-lib.google.bigquery.bigquery"] = "modules/centreon-stream-connectors-lib/google/bigquery/bigquery.lua"
+   }
+}

--- a/modules/specs/3.5.x/centreon-stream-connectors-lib-3.5.2-1.rockspec
+++ b/modules/specs/3.5.x/centreon-stream-connectors-lib-3.5.2-1.rockspec
@@ -1,0 +1,39 @@
+package = "centreon-stream-connectors-lib"
+version = "3.5.2-1"
+source = {
+   url = "git+https://github.com/centreon/centreon-stream-connector-scripts",
+   tag = "3.5.2-1"
+}
+description = {
+   summary = "Centreon stream connectors lua modules",
+   detailed = [[
+      Those modules provides helpful methods to create
+      stream connectors for Centreon
+   ]],
+   license = ""
+}
+dependencies = {
+   "lua >= 5.1, < 5.4",
+   "luasocket >= 3.0rc1-2"
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["centreon-stream-connectors-lib.sc_broker"] = "modules/centreon-stream-connectors-lib/sc_broker.lua",
+     ["centreon-stream-connectors-lib.sc_common"] = "modules/centreon-stream-connectors-lib/sc_common.lua",
+     ["centreon-stream-connectors-lib.sc_event"] = "modules/centreon-stream-connectors-lib/sc_event.lua",
+     ["centreon-stream-connectors-lib.sc_logger"] = "modules/centreon-stream-connectors-lib/sc_logger.lua",
+     ["centreon-stream-connectors-lib.sc_params"] = "modules/centreon-stream-connectors-lib/sc_params.lua",
+     ["centreon-stream-connectors-lib.sc_test"] = "modules/centreon-stream-connectors-lib/sc_test.lua",
+     ["centreon-stream-connectors-lib.sc_macros"] = "modules/centreon-stream-connectors-lib/sc_macros.lua",
+     ["centreon-stream-connectors-lib.sc_flush"] = "modules/centreon-stream-connectors-lib/sc_flush.lua",
+     ["centreon-stream-connectors-lib.sc_metrics"] = "modules/centreon-stream-connectors-lib/sc_metrics.lua",
+     ["centreon-stream-connectors-lib.rdkafka.config"] = "modules/centreon-stream-connectors-lib/rdkafka/config.lua",
+     ["centreon-stream-connectors-lib.rdkafka.librdkafka"] = "modules/centreon-stream-connectors-lib/rdkafka/librdkafka.lua",
+     ["centreon-stream-connectors-lib.rdkafka.producer"] = "modules/centreon-stream-connectors-lib/rdkafka/producer.lua",
+     ["centreon-stream-connectors-lib.rdkafka.topic_config"] = "modules/centreon-stream-connectors-lib/rdkafka/topic_config.lua",
+     ["centreon-stream-connectors-lib.rdkafka.topic"] = "modules/centreon-stream-connectors-lib/rdkafka/topic.lua",
+     ["centreon-stream-connectors-lib.google.auth.oauth"] = "modules/centreon-stream-connectors-lib/google/auth/oauth.lua",
+     ["centreon-stream-connectors-lib.google.bigquery.bigquery"] = "modules/centreon-stream-connectors-lib/google/bigquery/bigquery.lua"
+   }
+}


### PR DESCRIPTION
## Description

when you filter your events based on the name of a poller, it will never work  because the `if not self.event.cache.host.instance then` condition will never be true because the instance entry doesn't exist

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- have an apiv2 stream connector 
- put all your poller in the accepted_pollers parameter 
- without the patch, every events are going to be filtered out while they should all be accepted
- with the patch, it will work as intended

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

