### PR TITLE
Update servicenow-em-events-apiv2.lua

### DIFF
--- a/centreon-certified/servicenow/servicenow-em-events-apiv2.lua
+++ b/centreon-certified/servicenow/servicenow-em-events-apiv2.lua
@@ -61,6 +61,7 @@ function EventQueue.new (params)
   self.sc_params.params.client_secret = params.client_secret
   self.sc_params.params.username = params.username
   self.sc_params.params.password = params.password
+  self.sc_params.params.http_server_url = params.http_server_url or "service-now.com"
 
   self.sc_params.params.accepted_categories = params.accepted_categories or "neb"
   self.sc_params.params.accepted_elements = params.accepted_elements or "host_status,service_status"
@@ -237,7 +238,7 @@ function EventQueue:call(url, method, data, authToken)
     }
   end
 
-  local endpoint = "https://" .. tostring(self.sc_params.params.instance) .. ".service-now.com/" .. tostring(url)
+  local endpoint = "https://" .. tostring(self.sc_params.params.instance) .. "." .. self.sc_params.params.http_server_url .. "/" .. tostring(url)
   self.sc_logger:debug("EventQueue:call: Prepare url " .. endpoint)
 
   self.sc_logger:log_curl_command(endpoint, queue_metadata, self.sc_params.params, data)
@@ -271,7 +272,7 @@ function EventQueue:call(url, method, data, authToken)
   -- set proxy user configuration
   if (self.sc_params.params.proxy_username ~= '') then
     if (self.sc_params.params.proxy_password ~= '') then
-      request:setopt(curl.OPT_PROXYUSERPWD, self.proxy_username .. ':' .. self.sc_params.params.proxy_password)
+      request:setopt(curl.OPT_PROXYUSERPWD, self.sc_params.params.proxy_username .. ':' .. self.sc_params.params.proxy_password)
     else
       self.sc_logger:error("EventQueue:call: proxy_password parameter is not set but proxy_username is used")
     end


### PR DESCRIPTION
add http_server_url parm to use self hostet ServiceNow platform 
set http_server_url in endpoint string
change self.proxy_username to self.sc_params.params.proxy_username for use proxy server with auth

## Description

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [*] Patch fixing an issue (non-breaking change)
- [*] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [*] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Connect to a self hostet ServiceNow instence (no url service-now.com) over a proxy that required username and password.
 
Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [*] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
