### PR TITLE
handle beaker cookie auth with canopsis

### DIFF
--- a/centreon-certified/capensis/canopsis2-events-apiv2.lua
+++ b/centreon-certified/capensis/canopsis2-events-apiv2.lua
@@ -193,11 +193,11 @@ function EventQueue:get_beaker_cookie()
 
         -- split function may have splitted part of the header value, need to rebuild it if that's the case 
         if #parsed_headers > 2 then
-          for i=2,#header_split do
+          for i=2,#parsed_headers do
             header_string = header_string .. tostring(parsed_headers[i])
           end
         else
-          header_string = header_split[2]
+          header_string = parsed_headers[2]
         end
 
         headers[parsed_headers[1]] = header_string

--- a/centreon-certified/capensis/canopsis2-events-apiv2.lua
+++ b/centreon-certified/capensis/canopsis2-events-apiv2.lua
@@ -484,7 +484,10 @@ function EventQueue:send_data(payload, queue_metadata)
   }
 
   -- need to renew beaker cookie if it is too old
-  if os.time() - params.canopsis_cookie_lifespan >= self.cookie_info.creation_date then
+  if os.time() - params.canopsis_cookie_lifespan >= self.cookie_info.creation_date or not self.cookie_info.beaker_cookie then
+    self.sc_logger:notice("[EventQueue:send_data]: beaker cookie not found or too old. Beaker cookie was: " .. tostring(self.cookie_info.beaker_cookie)
+      .. ". Creation date is " .. tostring(os.date("%Y-%m-%d %X", self.cookie_info.creation_date)) .. ". It is more than " 
+      .. tostring(params.canopsis_cookie_lifespan) .. " seconds ago (you can change this delay with the canopsis_cookie_lifespan parameter)")
     local new_beaker_cookie = self:get_beaker_cookie()
     
     if new_beaker_cookie then


### PR DESCRIPTION
for compatibility reasons, it is needed to be able to send data to canopsis using a cookie.