### PR TITLE
fix bad url handling for log curl command

### DIFF
--- a/centreon-certified/logstash/logstash-events-apiv2.lua
+++ b/centreon-certified/logstash/logstash-events-apiv2.lua
@@ -193,6 +193,7 @@ end
 function EventQueue:send_data(payload, queue_metadata)
   self.sc_logger:debug("[EventQueue:send_data]: Starting to send data")
 
+  local url = self.sc_params.params.http_server_url .. ":" .. self.sc_params.params.port
   queue_metadata.headers = {"accept: application/json"}
   queue_metadata.method = "PUT"
   self.sc_logger:log_curl_command(url, queue_metadata, self.sc_params.params, payload)
@@ -204,11 +205,11 @@ function EventQueue:send_data(payload, queue_metadata)
   end
 
   self.sc_logger:info("[EventQueue:send_data]: Going to send the following json " .. tostring(payload))
-  self.sc_logger:info("[EventQueue:send_data]: Logstash address is: " .. tostring(self.sc_params.params.http_server_url .. ":" .. self.sc_params.params.port))
+  self.sc_logger:info("[EventQueue:send_data]: Logstash address is: " .. tostring(url))
 
   local http_response_body = ""
   local http_request = curl.easy()
-    :setopt_url(self.sc_params.params.http_server_url .. ":" .. self.sc_params.params.port)
+    :setopt_url(url)
     :setopt_writefunction(
       function (response)
         http_response_body = http_response_body .. tostring(response)


### PR DESCRIPTION
## Description
log_curl_commands param couldn't work because in the code, the log_curl_command function was using the `url` variable that doesn't exist.

`self.sc_logger:log_curl_command(url, queue_metadata, self.sc_params.params, payload)`

with this patch, the variable is now created

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
