### PR TITLE
enh(pack): two connectos were missing in the builds

### DIFF
--- a/centreon-certified/logstash/logstash-events-apiv2.lua
+++ b/centreon-certified/logstash/logstash-events-apiv2.lua
@@ -189,7 +189,6 @@ function EventQueue:build_payload(payload, event)
   return payload
 end
 
-
 function EventQueue:send_data(payload, queue_metadata)
   self.sc_logger:debug("[EventQueue:send_data]: Starting to send data")
 

--- a/centreon-certified/warp10/export-warp10-apiv1.lua
+++ b/centreon-certified/warp10/export-warp10-apiv1.lua
@@ -23,6 +23,7 @@
 -- token (string): the Warp10 write token
 -- max_size (number): how many queries to store before sending them to the server.
 --
+
 local curl = require "cURL"
 
 local my_data = {


### PR DESCRIPTION
## Description

A complement to yesterday's PR

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)
