### PR TITLE
MON-18829 sc handle deprecated max buffer age

### DIFF
--- a/modules/centreon-stream-connectors-lib/sc_params.lua
+++ b/modules/centreon-stream-connectors-lib/sc_params.lua
@@ -741,8 +741,6 @@ end
 -- @param param_name (string) the name of a parameter from the web interface
 -- @return if a match had been found with deprecated parameter : new_param_name (string) the right name of the parameter to avoid deprecated ones. Else, param_name is return.
 local function deprecated_params(param_name)
-  local final_param_name
-
   -- initiate deprecated parameters table
   local deprecated_params = {
     -- max_buffer_age param had been replace by max_all_queues_age

--- a/modules/centreon-stream-connectors-lib/sc_params.lua
+++ b/modules/centreon-stream-connectors-lib/sc_params.lua
@@ -738,6 +738,22 @@ function sc_params.new(common, logger)
   return self
 end
 
+--- deprecated_params: check if param_name provides from the web configuration is deprecated or not
+-- @param param_name (string) the name of a parameter from the web interface
+-- @return final_param_name (string) the right name of the parameter to avoid deprecated ones.
+function deprecated_params(param_name)
+  local final_param_name
+
+  -- max_buffer_age param had been replace by max_all_queues_age
+  if param_name == "max_buffer_age" then
+    final_param_name = "max_all_queues_age"
+  else
+    final_param_name = param_name
+  end
+
+  return final_param_name
+end
+
 --- param_override: change default param values with the one provides from the web configuration
 -- @param user_params (table) the table of all parameters from the web interface
 function ScParams:param_override(user_params)
@@ -748,11 +764,18 @@ function ScParams:param_override(user_params)
 
   for param_name, param_value in pairs(user_params) do
     if self.params[param_name] or string.find(param_name, "^_sc") ~= nil then
-      self.params[param_name] = param_value
-      self.logger:notice("[sc_params:param_override]: overriding parameter: " .. tostring(param_name) .. " with value: " .. tostring(param_value))
-    else 
+
+      -- Check if the param is deprecated
+      local param_name_verified = deprecated_params(param_name)
+      if param_name_verified ~= param_name then
+        self.logger:notice("[sc_params:param_override]: following parameter: " .. tostring(param_name) .. " is deprecated and had been replace by : " .. tostring(param_name_verified))
+      end
+
+    self.params[param_name_verified] = param_value
+    self.logger:notice("[sc_params:param_override]: overriding parameter: " .. tostring(param_name) .. " with value: " .. tostring(param_value))
+    else
       self.logger:notice("[sc_params:param_override]: User parameter: " .. tostring(param_name) .. " is not handled by this stream connector")
-    end
+      end
   end
 end
 

--- a/modules/centreon-stream-connectors-lib/sc_params.lua
+++ b/modules/centreon-stream-connectors-lib/sc_params.lua
@@ -751,7 +751,6 @@ function deprecated_params(param_name)
     return param_name
   end
 
-
 end
 
 --- param_override: change default param values with the one provides from the web configuration

--- a/modules/centreon-stream-connectors-lib/sc_params.lua
+++ b/modules/centreon-stream-connectors-lib/sc_params.lua
@@ -775,7 +775,7 @@ function ScParams:param_override(user_params)
     self.logger:notice("[sc_params:param_override]: overriding parameter: " .. tostring(param_name) .. " with value: " .. tostring(param_value))
     else
       self.logger:notice("[sc_params:param_override]: User parameter: " .. tostring(param_name) .. " is not handled by this stream connector")
-      end
+    end
   end
 end
 

--- a/modules/centreon-stream-connectors-lib/sc_params.lua
+++ b/modules/centreon-stream-connectors-lib/sc_params.lua
@@ -746,12 +746,12 @@ function deprecated_params(param_name)
 
   -- max_buffer_age param had been replace by max_all_queues_age
   if param_name == "max_buffer_age" then
-    final_param_name = "max_all_queues_age"
+    return "max_all_queues_age"
   else
-    final_param_name = param_name
+    return param_name
   end
 
-  return final_param_name
+
 end
 
 --- param_override: change default param values with the one provides from the web configuration
@@ -768,14 +768,14 @@ function ScParams:param_override(user_params)
       -- Check if the param is deprecated
       local param_name_verified = deprecated_params(param_name)
       if param_name_verified ~= param_name then
-        self.logger:notice("[sc_params:param_override]: following parameter: " .. tostring(param_name) .. " is deprecated and had been replace by : " .. tostring(param_name_verified))
+        self.logger:notice("[sc_params:param_override]: following parameter: " .. tostring(param_name) .. " is deprecated and had been replace by: " .. tostring(param_name_verified))
       end
 
     self.params[param_name_verified] = param_value
-    self.logger:notice("[sc_params:param_override]: overriding parameter: " .. tostring(param_name) .. " with value: " .. tostring(param_value))
+    self.logger:notice("[sc_params:param_override]: overriding parameter: " .. tostring(param_name_verified) .. " with value: " .. tostring(param_value))
     else
-      self.logger:notice("[sc_params:param_override]: User parameter: " .. tostring(param_name) .. " is not handled by this stream connector")
-    end
+      self.logger:notice("[sc_params:param_override]: User parameter: " .. tostring(param_name_verified) .. " is not handled by this stream connector")
+      end
   end
 end
 

--- a/modules/centreon-stream-connectors-lib/sc_params.lua
+++ b/modules/centreon-stream-connectors-lib/sc_params.lua
@@ -732,7 +732,6 @@ function sc_params.new(common, logger)
   -- acknowledgement status mapping
   self.params.status_mapping[categories.neb.id][elements.acknowledgement.id].host_status = self.params.status_mapping[categories.neb.id][elements.host_status.id]
   self.params.status_mapping[categories.neb.id][elements.acknowledgement.id].service_status = self.params.status_mapping[categories.neb.id][elements.service_status.id]
-  
 
   setmetatable(self, { __index = ScParams })
   return self
@@ -740,16 +739,22 @@ end
 
 --- deprecated_params: check if param_name provides from the web configuration is deprecated or not
 -- @param param_name (string) the name of a parameter from the web interface
--- @return final_param_name (string) the right name of the parameter to avoid deprecated ones.
-function deprecated_params(param_name)
+-- @return if a match had been found with deprecated parameter : new_param_name (string) the right name of the parameter to avoid deprecated ones. Else, param_name is return.
+local function deprecated_params(param_name)
   local final_param_name
 
-  -- max_buffer_age param had been replace by max_all_queues_age
-  if param_name == "max_buffer_age" then
-    return "max_all_queues_age"
-  else
-    return param_name
+  -- initiate deprecated parameters table
+  local deprecated_params = {
+    -- max_buffer_age param had been replace by max_all_queues_age
+    ["max_buffer_age"] = "max_all_queues_age"
+  }
+
+  for deprecated_param_name, new_param_name in pairs(deprecated_params) do
+    if param_name == deprecated_param_name then
+      return new_param_name
+    end
   end
+  return param_name
 
 end
 


### PR DESCRIPTION
## Description

Enhance sc_params lib to handle with deprecated parameters like max buffer age 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

In VM add Stream connector Lua output and set as parameter "max_buffer_age" at 10 for example
Output should show : 
```[sc_params:param_override]: following parameter: " max_buffer_age " is deprecated and had been replace by: "max_all_queues_age"```

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
