### PR TITLE
fix(packaging): set default release number to 1

### DIFF
--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -64,7 +64,7 @@ runs:
           export DIST=""
           if [ "${{ inputs.stability }}" = "unstable" ] || [ "${{ inputs.stability }}" = "canary" ]; then
             export RELEASE="$RELEASE~${{ inputs.distrib }}"
-          elif [ "${{ inputs.stability }}" = "testing" ]; then
+          else
             export RELEASE="1~${{ inputs.distrib }}"
           fi
         fi


### PR DESCRIPTION
## Description

since there is no promote job on this repository, set default release number to 1

**Fixes** MON-34730

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)