### PR TITLE
fix filters when using custom code

### DIFF
--- a/modules/centreon-stream-connectors-lib/sc_event.lua
+++ b/modules/centreon-stream-connectors-lib/sc_event.lua
@@ -76,6 +76,11 @@ function ScEvent:is_valid_event()
     is_valid_event = self:is_valid_bam_event()
   end
 
+  -- drop the event if it was not valid. Custom code do not have to work on already invalid events
+  if not is_valid_event then
+    return is_valid_event
+  end
+
   -- run custom code
   if self.params.custom_code and type(self.params.custom_code) == "function" then
     self, is_valid_event = self.params.custom_code(self)


### PR DESCRIPTION
## Description

when you use custom code, when it returns true, it will override every filters from the stream connector libs. Therefore, you will probably send undesired events.


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

create the following custom code

```
local self = ...

-- do not forget to add a line return after true
return self, true

```

pick any stream connector, add the custom code option, add the send_data_test option.

add any filter option such as a hostgroup filter.

Without this patch and with the custom code enabled, you will receive all events even the ones coming from hosts that do not belong to the hostgroup.
Without this patch and with the custom code disabled, you will receive events only from hosts belonging to the hostgroup

with the patch, you will always only receive events from hosts belonging to the hostgroup (with or without using custom code)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
