### PR TITLE
Update canopsis2x-events-apiv2.lua according capensis feedback

### DIFF
--- a/centreon-certified/canopsis/canopsis2x-events-apiv2.lua
+++ b/centreon-certified/canopsis/canopsis2x-events-apiv2.lua
@@ -417,7 +417,7 @@ function EventQueue:format_event_downtime()
       entity_pattern = {
         {
           {
-            field = "name",
+            field = "_id",
             cond = {
               type = "eq"
             }


### PR DESCRIPTION
## Description

Quick fix in canopsis2x-events-apiv2.lua according capensis feedback.
"Après avoir voulu tester le connecteur pour une présentation, nous avons pu remarqué que dans le entity_pattern, dans le champ "field" tu utilises "name" alors qu'il faudrait que ça soit _id"

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] master
