### PR TITLE
fix scshort macro flag

### DIFF
--- a/modules/centreon-stream-connectors-lib/sc_macros.lua
+++ b/modules/centreon-stream-connectors-lib/sc_macros.lua
@@ -499,7 +499,7 @@ end
 -- @param macro_value (string) the string that needs to be shortened
 -- @return string (string) the input string with only the first lne
 function ScMacros:transform_short(macro_value)
-  return string.match(macro_value, "^(.*)\n")
+  return string.match(macro_value, "^(.*)\n") or macro_value
 end
 
 --- transform_type: convert a 0, 1 value into SOFT or HARD


### PR DESCRIPTION
when you use a macro such as 

{output_schort] or {cache.service.output_scshort} 

and you don't have a line return in the string that is going to be transformed, the _scshort flag will return a nil a value. Therefore, the macro mecanism will say that the used macro is not a valid one and you will end up with the macro  name in your event instead of the value.


how to test it: 

create a format file such as 

```json
{
        "neb_service_status": {
                "output": "{output}",
                "short_output": "{short_output}",
                "long_output": "{long_output}",
                "short_output_flag": "{output_scshort}",
                "cache_output": "{cache.service.output}",
                "cache_short_output_flag": "{cache.service.output_scshort}"
        }
}
```

use a  stream connector that is compatible with the custom format feature. 

send an event with a long output (for example,  storage mode of linux plugin with the verbose option,

```json
{
  "source": "",
  "index": "",
  "sourcetype": "_json",
  "event": {
    "output": "OK: All storages are ok",
    "cache_output": "OK: All storages are ok",
    "long_output": "OK: All storages are ok\\nStorage /dev/shm Usage Total: 881.85 MB Used: 24.00 KB (0.00%) Free: 881.82 MB (100.00%)\\\\nStorage /run Usage Total: 352.74 MB Used: 6.11 MB (1.73%) Free: 346.64 MB (98.27%)\\\\nStorage / Usage Total: 7.99 GB Used: 5.27 GB (65.99%) Free: 2.72 GB (34.01%)\\\\nStorage /boot Usage Total: 1014.00 MB Used: 437.65 MB (43.16%) Free: 576.35 MB (56.84%)\\\\nStorage /run/user/0 Usage Total: 176.37 MB Used: 0.00 B (0.00%) Free: 176.37 MB (100.00%)\\\\n",
    "short_output": "OK: All storages are ok",
    "cache_short_output_flag": "OK: All storages are ok",
    "short_output_flag": "OK: All storages are ok"
  },
  "time": 1719817699,
  "host": "Central"
}
```

without the patch 

```json
{
  "index": "",
  "sourcetype": "_json",
  "time": 1719818039,
  "source": "",
  "host": "Central",
  "event": {
    "cache_output": "OK: All storages are ok",
    "output": "OK: All storages are ok",
    "cache_short_output_flag": "{cache.service.output_scshort}",
    "long_output": "OK: All storages are ok\\nStorage /dev/shm Usage Total: 881.85 MB Used: 24.00 KB (0.00%) Free: 881.82 MB (100.00%)\\\\nStorage /run Usage Total: 352.74 MB Used: 6.11 MB (1.73%) Free: 346.64 MB (98.27%)\\\\nStorage / Usage Total: 7.99 GB Used: 5.27 GB (66.01%) Free: 2.71 GB (33.99%)\\\\nStorage /boot Usage Total: 1014.00 MB Used: 437.65 MB (43.16%) Free: 576.35 MB (56.84%)\\\\nStorage /run/user/0 Usage Total: 176.37 MB Used: 0.00 B (0.00%) Free: 176.37 MB (100.00%)\\\\n",
    "short_output": "OK: All storages are ok",
    "short_output_flag": "{output_scshort}"
  }
}
```

this must also be tested with plugin that returns a very simple output, such as the ping one

without the patch 

```json
{
  "index": "",
  "sourcetype": "_json",
  "time": 1719818149,
  "source": "",
  "host": "Central",
  "event": {
    "cache_output": "OK - 127.0.0.1 rta 0,011ms lost 0%",
    "output": "OK - 127.0.0.1 rta 0,011ms lost 0%",
    "cache_short_output_flag": "{cache.service.output_scshort}",
    "long_output": "OK - 127.0.0.1 rta 0,011ms lost 0%",
    "short_output": "OK - 127.0.0.1 rta 0,011ms lost 0%",
    "short_output_flag": "{output_scshort}"
  }
}
```

with the patch

```json
{
  "source": "",
  "event": {
    "cache_short_output_flag": "OK - 127.0.0.1 rta 0,013ms lost 0%",
    "short_output": "OK - 127.0.0.1 rta 0,013ms lost 0%",
    "long_output": "OK - 127.0.0.1 rta 0,013ms lost 0%",
    "cache_output": "OK - 127.0.0.1 rta 0,013ms lost 0%",
    "output": "OK - 127.0.0.1 rta 0,013ms lost 0%",
    "short_output_flag": "OK - 127.0.0.1 rta 0,013ms lost 0%"
  },
  "host": "Central",
  "sourcetype": "_json",
  "time": 1719818344,
  "index": ""
}
```

