### PR TITLE
protect metric name

### DIFF
--- a/centreon-certified/clickhouse/clickhouse-metrics-apiv2.lua
+++ b/centreon-certified/clickhouse/clickhouse-metrics-apiv2.lua
@@ -401,7 +401,7 @@ function EventQueue:convert_metric_event(event)
   end
 
   -- hack event to make stream connector lib think it is a standard status neb event.
-  event.perfdata = event.name .. "=" .. event.value .. ";;;;"
+  event.perfdata = "'" .. event.name .. "'=" .. event.value .. ";;;;"
   event.category = params.bbdo.categories["neb"].id
   event.last_check = event.time or event.ctime
 

--- a/centreon-certified/influxdb/influxdb2-metrics-apiv2.lua
+++ b/centreon-certified/influxdb/influxdb2-metrics-apiv2.lua
@@ -355,7 +355,7 @@ function EventQueue:convert_metric_event(event)
   end
 
   -- hack event to make stream connector lib think it is a standard status neb event.
-  event.perfdata = event.name .. "=" .. event.value .. ";;;;"
+  event.perfdata = "'" .. event.name .. "'=" .. event.value .. ";;;;"
   event.category = params.bbdo.categories["neb"].id
 
   if not event.ctime then


### PR DESCRIPTION
for both stream connectors (clickhouse and influxdb2-metrics) if you are using the use_deprecated_metric_system option and your metric name contains a space, it will break the metric name and it will only keep the last word of your metric.

for example if your metric name is "my super metric name" then those stream connectors will only send "name"  instead of "my super metric name"

