### PR TITLE
add pcall in the flush_payload method

### DIFF
--- a/modules/centreon-stream-connectors-lib/sc_flush.lua
+++ b/modules/centreon-stream-connectors-lib/sc_flush.lua
@@ -211,12 +211,16 @@ end
 -- @return boolean (boolean) true or false depending on the success of the operation
 function ScFlush:flush_payload(send_method, payload, metadata)
   if payload then
-    if not send_method(payload, metadata) then
+    local pcall_status, result = pcall(send_method, payload, metadata)
+    self.sc_logger:debug("[sc_flush:flush_payload]: tried to send payload protected by pcall. Status: " .. tostring(status) .. ", Message: " .. tostring(err))
+
+    if not pcall_status then
+      self.sc_logger:error("[sc_flush:flush_payload]: could not send payload because of an internal error. pcall status: " .. tostring(pcall_status) .. ", error message: " .. tostring(result))
       return false
     end
   end
 
-  return true
+  return result
 end
 
 return sc_flush


### PR DESCRIPTION
properly log curl errors (or any weird errors coming from the send_data method that is called by the flush_method in the sc_flush.lua module)

whithout this patch, broker would display a meaningless error in its own log file. The stream connector log file wasn't letting you know that something was wrong.

Now  broker won't log any error message and a beautiful error will displayed in your stream connector log file such as 

```txt
Fri Aug 23 10:59:25 2024: ERROR: [EventQueue:send_data]: HTTP POST request FAILED, return code is 403. Message is: Code: 516. DB::Exception: centreon: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED) (version 24.8.1.2203 (official build))
``` 