### PR TITLE
fix canopsis duplicate data

### DIFF
--- a/centreon-certified/canopsis/canopsis2x-events-apiv2.lua
+++ b/centreon-certified/canopsis/canopsis2x-events-apiv2.lua
@@ -776,6 +776,15 @@ function EventQueue:postCanopsisAPI(self_metadata, route, data_to_send)
     self.sc_logger:notice("[postCanopsisAPI]: HTTP POST request successful: return code is "
     .. tostring(http_response_code))
     retval = true
+  elseif http_response_code == 400 and string.find(tostring(http_response_body), "ID already exists") then
+    self.sc_logger:notice("[EventQueue:send_data]: Tried to send duplicate data. It is going to be ignored. "
+      .. "return code is: " .. tostring(http_response_body) .. ". Message is: " .. tostring(http_response_body))
+    
+      if payload then
+        self.sc_logger:notice("[EventQueue:send_data]: sent payload was: " .. tostring(data_to_send))
+      end
+    
+    retval = true
   else
     self.sc_logger:error("[postCanopsisAPI]: HTTP POST request FAILED, return code is "
       .. tostring(http_response_code) .. ". Message is: " .. tostring(http_response_body))

--- a/centreon-certified/canopsis/canopsis2x-events-apiv2.lua
+++ b/centreon-certified/canopsis/canopsis2x-events-apiv2.lua
@@ -592,7 +592,7 @@ function EventQueue:send_data(payload, queue_metadata)
     end
 
     retval = true
-  elseif http_response_code == 400 and string.match(http_response_body, "Trying to insert PBehavior with already existing _id") then
+  elseif http_response_code == 400 and (string.match(tostring(http_response_body), "Trying to insert PBehavior with already existing _id") or string.find(tostring(http_response_body), "ID already exists")) then
     self.sc_logger:notice("[EventQueue:send_data]: Ignoring downtime with id: " .. tostring(payload._id)
       .. ". Canopsis result: " .. tostring(http_response_body))
     self.sc_logger:info("[EventQueue:send_data]: duplicated downtime event: " .. tostring(data))
@@ -775,15 +775,6 @@ function EventQueue:postCanopsisAPI(self_metadata, route, data_to_send)
       .. tostring(http_response_code))
     self.sc_logger:notice("[postCanopsisAPI]: HTTP POST request successful: return code is "
     .. tostring(http_response_code))
-    retval = true
-  elseif http_response_code == 400 and string.find(tostring(http_response_body), "ID already exists") then
-    self.sc_logger:notice("[EventQueue:send_data]: Tried to send duplicate data. It is going to be ignored. "
-      .. "return code is: " .. tostring(http_response_body) .. ". Message is: " .. tostring(http_response_body))
-    
-    if payload then
-      self.sc_logger:notice("[EventQueue:send_data]: sent payload was: " .. tostring(data_to_send))
-    end
-    
     retval = true
   else
     self.sc_logger:error("[postCanopsisAPI]: HTTP POST request FAILED, return code is "

--- a/centreon-certified/canopsis/canopsis2x-events-apiv2.lua
+++ b/centreon-certified/canopsis/canopsis2x-events-apiv2.lua
@@ -780,9 +780,9 @@ function EventQueue:postCanopsisAPI(self_metadata, route, data_to_send)
     self.sc_logger:notice("[EventQueue:send_data]: Tried to send duplicate data. It is going to be ignored. "
       .. "return code is: " .. tostring(http_response_body) .. ". Message is: " .. tostring(http_response_body))
     
-      if payload then
-        self.sc_logger:notice("[EventQueue:send_data]: sent payload was: " .. tostring(data_to_send))
-      end
+    if payload then
+      self.sc_logger:notice("[EventQueue:send_data]: sent payload was: " .. tostring(data_to_send))
+    end
     
     retval = true
   else


### PR DESCRIPTION
## Description

sometimes when you send an event to canopsis (it looks like it is mostly downtimes), you all have the following error:

Fri Dec 13 10:30:56 2024: ERROR: [EventQueue:send_data]: HTTP POST request FAILED, return code is 400. Message is: {"errors":{"_id":"ID already exists."}}

when this happens, the stream connector will try to send this event again until the end of time. This creates retentions files and spams canopsis for no reason. 

In such case, we must log a notice message and return true instead of false. This way, broker will not loop over and over again on this message that can’t be send. We don’t mind ignoring this event since the message from canopsis means that it already received it.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>


## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
