### PR TITLE
fix downtimes events canopsis

### DIFF
--- a/centreon-certified/canopsis/canopsis2x-events-apiv2.lua
+++ b/centreon-certified/canopsis/canopsis2x-events-apiv2.lua
@@ -427,7 +427,8 @@ function EventQueue:format_event_downtime()
       -- exdates = {}
     }
 
-    if event.service_id then
+    -- in downtime events, service id is equal to 0 when the downtime is about a host (same for BBDO 2 and 3)
+    if event.service_id ~= 0 then
       self.sc_event.event.formated_event["entity_pattern"][1][1]["cond"]["value"] = tostring(event.cache.service.description)
         .. "/" .. tostring(event.cache.host.name)
     else
@@ -592,10 +593,15 @@ function EventQueue:send_data(payload, queue_metadata)
     end
 
     retval = true
-  elseif http_response_code == 400 and string.match(http_response_body, "Trying to insert PBehavior with already existing _id") then
+  elseif http_response_code == 400 and (string.match(tostring(http_response_body), "Trying to insert PBehavior with already existing _id") or string.find(tostring(http_response_body), "ID already exists")) then
     self.sc_logger:notice("[EventQueue:send_data]: Ignoring downtime with id: " .. tostring(payload._id)
       .. ". Canopsis result: " .. tostring(http_response_body))
     self.sc_logger:info("[EventQueue:send_data]: duplicated downtime event: " .. tostring(data))
+    retval = true
+  elseif http_response_code == 404 and (string.match(tostring(http_response_body), "Not found")) then
+    self.sc_logger:notice("[EventQueue:send_data]: Ignoring downtime deletion with id: " .. tostring(payload.name)
+      .. ". Canopsis result: " .. tostring(http_response_body))
+    self.sc_logger:info("[EventQueue:send_data]: downtime already removed. event: " .. tostring(data))
     retval = true
   else
     self.sc_logger:error("[EventQueue:send_data]: HTTP " .. http_method .. " request FAILED, return code is "

--- a/centreon-certified/canopsis/canopsis2x-events-apiv2.lua
+++ b/centreon-certified/canopsis/canopsis2x-events-apiv2.lua
@@ -387,7 +387,12 @@ function EventQueue:format_event_downtime()
 
   local event = self.sc_event.event
   local elements = self.sc_params.params.bbdo.elements
-  local downtime_name = "centreon-downtime-" .. event.internal_id .. "-" .. event.entry_time
+
+  if not event.internal_id then
+    event.internal_id = event.id
+  end
+
+  local downtime_name = "centreon-downtime-" .. tostring(event.internal_id) .. "-" .. tostring(event.entry_time)
 
   if event.cancelled == true or (self.bbdo_version == 2 and event.deletion_time == 1) or (self.bbdo_version > 2 and event.deletion_time ~= -1) then
     local metadata = {


### PR DESCRIPTION
## Description

when you send a downtime for a host, the stream connector will wrongfully act like it is a downtime for a service because of an error on a condition in the code.

This leads to errors that will then make the stream connector loop through the same downtime event forever. And canopsis will answer with an error telling us that the downtime already exists.

+ if the stream connector tries to delete a downtime in canopsis. If the downtime doesn't exist, it will prompt another error that is not handled by the stream connector

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

enable downtime events for the stream connector by adding the "downtime" value in the accepted_elements parameter.
then put a downtime on a host. 

without the patch you'll have an error in your broker log about a nil index "service".
with the patch it's all good

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
