### PR TITLE
fix oauth refresh token params #255

### DIFF
--- a/centreon-certified/servicenow/servicenow-em-events-apiv2.lua
+++ b/centreon-certified/servicenow/servicenow-em-events-apiv2.lua
@@ -158,7 +158,7 @@ end
 -- refreshToken: refresh auth token
 --------------------------------------------------------------------------------
 function EventQueue:refreshToken (token)
-  local data = "grant_type=refresh_token&client_id=" .. broker.url_encode(self.sc_params.params.client_id) .. "&client_secret=" .. broker.url_encode(self.sc_params.params.client_secret) .. "&username=" .. broker.url_encode(self.sc_params.params.username) .. "&password=" .. broker.url_encode(self.sc_params.params.password)
+  local data = "grant_type=refresh_token&client_id=" .. broker.url_encode(self.sc_params.params.client_id) .. "&client_secret=" .. broker.url_encode(self.sc_params.params.client_secret)
   
   local res = self:call(
     "oauth_token.do",

--- a/centreon-certified/servicenow/servicenow-incident-events-apiv2.lua
+++ b/centreon-certified/servicenow/servicenow-incident-events-apiv2.lua
@@ -167,7 +167,7 @@ end
 -- refreshToken: refresh auth token
 --------------------------------------------------------------------------------
 function EventQueue:refreshToken (token)
-  local data = "grant_type=refresh_token&client_id=" .. broker.url_encode(self.sc_params.params.client_id) .. "&client_secret=" .. broker.url_encode(self.sc_params.params.client_secret) .. "&username=" .. broker.url_encode(self.sc_params.params.username) .. "&password=" .. broker.url_encode(self.sc_params.params.password)
+  local data = "grant_type=refresh_token&client_id=" .. broker.url_encode(self.sc_params.params.client_id) .. "&client_secret=" .. broker.url_encode(self.sc_params.params.client_secret)
   
   local res = self:call(
     "oauth_token.do",


### PR DESCRIPTION
## Description

fix copy/paste mistake that introduced useless parameters in the refresh token part of snow stream connectors

**Fixes** #255

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>



Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
