### PR TITLE
fix influxdb2 metrics and subinstances #259

### DIFF
--- a/centreon-certified/influxdb/influxdb2-metrics-apiv2.lua
+++ b/centreon-certified/influxdb/influxdb2-metrics-apiv2.lua
@@ -219,8 +219,8 @@ function EventQueue:build_generic_tags(metric)
 
   -- add metric subinstances in tags
   if metric.subinstance[1] then
-    for subinstance_name, subinstance_value in ipairs(metric.subinstance) do
-      tags = tags .. ',' .. self.sc_common:trim(subinstance_name, "_") .. '=' .. self:escape_special_characters(subinstance_value)
+    for subinstance_id, subinstance_name in ipairs(metric.subinstance) do
+      tags = tags .. ',subinstance_' .. subinstance_id .. '=' .. self:escape_special_characters(subinstance_name)
     end
   end
 


### PR DESCRIPTION
## Description

when you have a metric with subinstances. The stream connector will fail with the below error

```txt
[2025-02-04T14:45:15.705-05:00] [lua] [error] lua: error running function `write' /usr/share/lua/5.3/centreon-stream-connectors-lib/sc_common.lua:336: attempt to index a number value (local 'string')
```

that's because we do not properly handle metric with subinstances such as the below one

```txt
'PingSDWan~vdom~ifName#azure.insights.logicaldisk.free.percentage'=94.82%;;;0;100
```

(there tare two subinstances vdom and ifname)



**Fixes** #259  (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
