### PR TITLE
fix wrong logging of unhandled params

### DIFF
--- a/modules/centreon-stream-connectors-lib/sc_params.lua
+++ b/modules/centreon-stream-connectors-lib/sc_params.lua
@@ -964,7 +964,7 @@ function ScParams:param_override(user_params)
       end
       self.logger:notice("[sc_params:param_override]: overriding parameter: " .. tostring(param_name_verified) .. " with value: " .. tostring(logged_param_value))
     else
-      self.logger:notice("[sc_params:param_override]: User parameter: " .. tostring(param_name_verified) .. " is not handled by this stream connector")
+      self.logger:notice("[sc_params:param_override]: User parameter: " .. tostring(param_name) .. " is not handled by this stream connector")
     end
   end
 end


### PR DESCRIPTION
## Description

when you put an unknown parameter in your stream connector config, it should display in the log file that the parameter is not handled and is going to be ignored. It must clearly display the name of the unknown parameter to help you find out if you've made a typo or something else.

Which is not the case at the moment

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

put a random parameter (that doesn't exist) in your stream connector

without the patch you'll have the following result : 

```txt
Tue Feb 11 10:14:00 2025: INFO: [sc_params:param_override]: User parameter: nil is not handled by this stream connector
Tue Feb 11 10:14:00 2025: INFO: [sc_params:param_override]: overriding parameter: user with value: dazdza
Tue Feb 11 10:14:00 2025: INFO: [sc_params:param_override]: User parameter: nil is not handled by this stream connector
Tue Feb 11 10:14:00 2025: INFO: [sc_params:param_override]: overriding parameter: send_data_test with value: 1
Tue Feb 11 10:14:00 2025: INFO: [sc_params:param_override]: overriding parameter: password with value: ******
```

with the patch you'll have 

```txt
Tue Feb 11 11:32:38 2025: INFO: [sc_params:param_override]: User parameter: enable_trace is not handled by this stream connector
Tue Feb 11 11:32:38 2025: INFO: [sc_params:param_override]: overriding parameter: send_data_test with value: 1
Tue Feb 11 11:32:38 2025: INFO: [sc_params:param_override]: overriding parameter: user with value: dazdza
Tue Feb 11 11:32:38 2025: INFO: [sc_params:param_override]: overriding parameter: use_deprecated_metric_system with value: 1
Tue Feb 11 11:32:38 2025: INFO: [sc_params:param_override]: overriding parameter: password with value: ******
Tue Feb 11 11:32:38 2025: INFO: [sc_params:param_override]: overriding parameter: http_server_url with value: dzadzadza
Tue Feb 11 11:32:38 2025: INFO: [sc_params:param_override]: User parameter: trace_host_id_list is not handled by this stream connector
```

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
