### PR TITLE
ci(secu): replace gitleaks secret and remove PRT

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: gitleaks/gitleaks-action@83373cf2f8c4db6e24b41c1a9b086bb9619e9cd3 # v2.3.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}}
+          GITLEAKS_LICENSE: "Centreon"
           GITLEAKS_ENABLE_COMMENTS: false
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
           GITLEAKS_ENABLE_SUMMARY: false

--- a/.github/workflows/set-pull-request-external-label.yml
+++ b/.github/workflows/set-pull-request-external-label.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request_target:
+  pull_request:
 
 jobs:
   set-pull-request-external-label:


### PR DESCRIPTION
## Description

Remove secret in order to allow dependabot and external PR to be able to run the gitleaks mandatory workflow