### PR TITLE
Ctor 1622 really use broker apiv2

### DIFF
--- a/modules/centreon-stream-connectors-lib/sc_broker.lua
+++ b/modules/centreon-stream-connectors-lib/sc_broker.lua
@@ -13,9 +13,7 @@ local ScBroker = {}
 
 function sc_broker.new(logger)
   local self = {}
-  
-  broker_api_version = 2
-  
+
   self.logger = logger
   if not self.logger then 
     self.logger = sc_logger.new()

--- a/modules/centreon-stream-connectors-lib/sc_event.lua
+++ b/modules/centreon-stream-connectors-lib/sc_event.lua
@@ -14,7 +14,7 @@ local sc_broker = require("centreon-stream-connectors-lib.sc_broker")
 
 local ScEvent = {}
 
-function sc_event.new(event, params, common, logger, broker)
+function sc_event.new(broker_event, params, common, logger, broker)
   local self = {}
 
   self.sc_logger = logger
@@ -23,11 +23,21 @@ function sc_event.new(event, params, common, logger, broker)
   end
   self.sc_common = common
   self.params = params
-  self.event = event
+  self.broker_event = broker_event
   self.sc_broker = broker
   self.bbdo_version = self.sc_common:get_bbdo_version()
 
-  self.event.cache = {}
+  -- we put the broker_event userdata in a variable from our object this way it will be accessible from anywhere 
+  self.broker_event = broker_event
+
+  -- we create our event table
+  self.event = {
+    cache = {}
+  }
+
+  -- create the meta table for the self.event table
+  local event_meta = { __index = function (tbl, key) return self.broker_event[key] end}
+  setmetatable(self.event, event_meta)
 
   setmetatable(self, { __index = ScEvent })
   return self

--- a/modules/centreon-stream-connectors-lib/sc_event.lua
+++ b/modules/centreon-stream-connectors-lib/sc_event.lua
@@ -27,9 +27,6 @@ function sc_event.new(broker_event, params, common, logger, broker)
   self.sc_broker = broker
   self.bbdo_version = self.sc_common:get_bbdo_version()
 
-  -- we put the broker_event userdata in a variable from our object this way it will be accessible from anywhere 
-  self.broker_event = broker_event
-
   -- we create our event table
   self.event = {
     cache = {}

--- a/modules/centreon-stream-connectors-lib/sc_params.lua
+++ b/modules/centreon-stream-connectors-lib/sc_params.lua
@@ -1,5 +1,7 @@
 #!/usr/bin/lua
 
+broker_api_version = 2
+
 --- 
 -- Module to help initiate a stream connector with all paramaters
 -- @module sc_params


### PR DESCRIPTION
## Description

stream connectors weren't using the broker api v2 at all because the broker_api_version global variable wasn't set up like it should.
sadly, stream connectors have been made around an event table that is in fact a userdata when using the api v2.

this patch converts the event table that we were using into a metatable that will return the value from the userdata when not found in the event table.

this allow us to switch from api v1 to api v2 seemlessly 

In the meantime, I have also changed the file in which the broker_api_version variable is set. 
This is because it is a parameter (a special one but still a parameter) so it makes sense to have it in the parameter lib and also the sc_broker lib is about using the broker cache and not about the event.
Also, I plan on changing the architecture of the cache system one day or another and it will break everything if the broker_api_version variable is still there

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

- with any stream connector, with the send_data_test set to 1
- put the broker_api_version = 2 in the sc_params file like in the PR

generate an event
- without the patch, you'll get an error in the broker log file
- with the patch you must see your event in the stream connector log file

you can also set the broker_api_version variable to 1 and it must still work with the patch


## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
