### PR TITLE
enh(stream-connectors-lib): package lua-sql-mysql for el8 and el9

### DIFF
--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -38,6 +38,9 @@ inputs:
   stability:
     description: "Branch stability (stable, testing, unstable, canary)"
     required: true
+  artifact_name:
+    description: The name of the uploaded artifact
+    required: false
 
 runs:
   using: composite
@@ -98,11 +101,22 @@ runs:
         path: ./*.${{ inputs.package_extension }}
         key: ${{ inputs.cache_key }}
 
-    # Update if condition to true to get packages as artifacts
-    - if: ${{ false }}
+    # Add to your PR the label upload-artifacts to get packages as artifacts
+    - if: ${{ contains(github.event.pull_request.labels.*.name, 'upload-artifacts') }}
+      name: Get artifact name
+      id: get-artifact-name
+      run: |
+        if [ -z "${{ inputs.artifact_name }}" ]; then
+          echo "artifact_name=packages-${{ inputs.distrib }}" >> $GITHUB_OUTPUT
+        else
+          echo "artifact_name=${{ inputs.artifact_name }}" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+
+    - if: ${{ contains(github.event.pull_request.labels.*.name, 'upload-artifacts') }}
       name: Upload package artifacts
       uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
       with:
-        name: packages-${{ inputs.distrib }}
+        name: ${{ steps.get-artifact-name.outputs.artifact_name }}
         path: ./*.${{ inputs.package_extension}}
         retention-days: 1

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -28,12 +28,10 @@ jobs:
       matrix:
         distrib: [el8, el9]
         include:
-          - package_extension: rpm
-            image: packaging-stream-connectors-nfpm-alma8
+          - image: packaging-stream-connectors-nfpm-alma8
             distrib: el8
             lua_version: 5.3
-          - package_extension: rpm
-            image: packaging-stream-connectors-nfpm-alma9
+          - image: packaging-stream-connectors-nfpm-alma9
             distrib: el9
             lua_version: 5.4
 
@@ -79,12 +77,12 @@ jobs:
         with:
           nfpm_file_pattern: "dependencies/lua-sql-mysql/packaging/*.yaml"
           distrib: ${{ matrix.distrib }}
-          package_extension: ${{ matrix.package_extension }}
+          package_extension: rpm
           arch: amd64
           version: "2.6.0"
           release: "1"
           commit_hash: ${{ github.sha }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-lua-sql-mysql-${{ matrix.distrib }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-lua-sql-mysql-${{ matrix.distrib }}
           rpm_gpg_key: ${{ secrets.RPM_GPG_SIGNING_KEY }}
           rpm_gpg_signing_key_id: ${{ secrets.RPM_GPG_SIGNING_KEY_ID }}
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -66,7 +66,7 @@ jobs:
           fi
           dnf install -y make gcc lua lua-devel mysql mysql-devel
           cd lua-sql-src
-          make mysql DRIVER_LIBS_mysql=-L/usr/lib64/mysql DRIVER_INCS_mysql=-I/usr/include/mysql LUA_SYS_VER=${{ matrix.lua_version }}
+          make mysql DRIVER_LIBS_mysql="-L/usr/lib64/mysql -lmysqlclient" DRIVER_INCS_mysql=-I/usr/include/mysql LUA_SYS_VER=${{ matrix.lua_version }}
           cd ..
 
           sed -i "s/@luaver@/${{ matrix.lua_version }}/g" dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -70,8 +70,8 @@ jobs:
           cd lua-sql-src
           make mysql DRIVER_LIBS_mysql=-L/usr/lib64/mysql DRIVER_INCS_mysql=-I/usr/include/mysql LUA_SYS_VER=${{ matrix.lua_version }}
           cd ..
-          
-          sed -i "s/@luaver@/${{ matrix.lua_version }}/g" lua-sql-mysql/packaging/lua-sql-mysql.yaml
+
+          sed -i "s/@luaver@/${{ matrix.lua_version }}/g" dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
         shell: bash
 
       - name: Package

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -1,0 +1,113 @@
+name: lua-sql-mysql
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - dependencies/lua-sql-mysql/**
+  push:
+    branches:
+      - develop
+      - master
+    paths:
+      - dependencies/lua-sql-mysql/**
+
+jobs:
+  get-environment:
+    uses: ./.github/workflows/get-environment.yml
+
+  package:
+    needs: [get-environment]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        distrib: [el8, el9]
+        include:
+          - package_extension: rpm
+            image: packaging-stream-connectors-nfpm-alma8
+            distrib: el8
+            lua_version: 5.3
+          - package_extension: rpm
+            image: packaging-stream-connectors-nfpm-alma9
+            distrib: el9
+            lua_version: 5.4
+
+    runs-on: ubuntu-24.04
+
+    container:
+      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:latest
+      credentials:
+        username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+        password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+
+    name: package ${{ matrix.distrib }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Checkout luasql sources
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "lunarmodules/luasql"
+          path: "lua-sql-src"
+          ref: "2.6.0"
+
+      - name: Prepare packaging of lua-sql-mysql
+        run: |
+          dnf install -y dnf-plugins-core
+          if [ "${{ matrix.distrib }}" == "el8" ]; then
+            dnf config-manager --set-enabled powertools
+          else
+            dnf config-manager --set-enabled crb
+          fi
+          dnf install -y make gcc lua lua-devel mysql mysql-devel
+          cd lua-sql-src
+          make mysql DRIVER_LIBS_mysql=-L/usr/lib64/mysql DRIVER_INCS_mysql=-I/usr/include/mysql LUA_SYS_VER=${{ matrix.lua_version }}
+          cd ..
+          
+          sed -i "s/@luaver@/${{ matrix.lua_version }}/g" lua-sql-mysql/packaging/lua-sql-mysql.yaml
+        shell: bash
+
+      - name: Package
+        uses: ./.github/actions/package-nfpm
+        with:
+          nfpm_file_pattern: "dependencies/lua-sql-mysql/packaging/*.yaml"
+          distrib: ${{ matrix.distrib }}
+          package_extension: ${{ matrix.package_extension }}
+          arch: amd64
+          version: "2.6.0"
+          release: "1"
+          commit_hash: ${{ github.sha }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-lua-sql-mysql-${{ matrix.distrib }}
+          rpm_gpg_key: ${{ secrets.RPM_GPG_SIGNING_KEY }}
+          rpm_gpg_signing_key_id: ${{ secrets.RPM_GPG_SIGNING_KEY_ID }}
+          rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+
+  deliver-rpm:
+    if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
+    needs: [get-environment, package]
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        distrib: [el8, el9]
+    name: deliver ${{ matrix.distrib }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Publish RPM packages
+        uses: ./.github/actions/rpm-delivery
+        with:
+          module_name: lua-sql-mysql
+          distrib: ${{ matrix.distrib }}
+          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-lua-sql-mysql-${{ matrix.distrib }}
+          stability: ${{ needs.get-environment.outputs.stability }}

--- a/dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
+++ b/dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
@@ -15,7 +15,7 @@ homepage: "https://www.centreon.com"
 license: "Apache-2.0"
 
 contents:
-  - src: "../../lua-curl-src/src/mysql.so.so"
+  - src: "../../lua-curl-src/src/mysql.so"
     dst: "/usr/lib64/lua/@luaver@/luasql/mysql.so"
     file_info:
       mode: 0644

--- a/dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
+++ b/dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
@@ -1,0 +1,33 @@
+name: "lua-sql-mysql"
+arch: "${ARCH}"
+platform: "linux"
+version_schema: "none"
+version: "${VERSION}"
+release: "${RELEASE}${DIST}"
+section: "default"
+priority: "optional"
+maintainer: "Centreon <contact@centreon.com>"
+description: |
+  LuaSQL MySQL library
+  Commit: @COMMIT_HASH@
+vendor: "Centreon"
+homepage: "https://www.centreon.com"
+license: "Apache-2.0"
+
+contents:
+  - src: "../../lua-curl-src/src/mysql.so.so"
+    dst: "/usr/lib64/lua/@luaver@/luasql/mysql.so"
+    file_info:
+      mode: 0644
+    packager: rpm
+
+overrides:
+  rpm:
+    depends:
+      - lua
+
+rpm:
+  summary: LuaSQL MySQL
+  signature:
+    key_file: ${RPM_SIGNING_KEY_FILE}
+    key_id: ${RPM_SIGNING_KEY_ID}

--- a/dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
+++ b/dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
@@ -15,7 +15,7 @@ homepage: "https://www.centreon.com"
 license: "Apache-2.0"
 
 contents:
-  - src: "../../lua-curl-src/src/mysql.so"
+  - src: "../../../lua-sql-src/src/mysql.so"
     dst: "/usr/lib64/lua/@luaver@/luasql/mysql.so"
     file_info:
       mode: 0644

--- a/dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
+++ b/dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
@@ -25,6 +25,7 @@ overrides:
   rpm:
     depends:
       - lua
+      - mysql-libs
 
 rpm:
   summary: LuaSQL MySQL


### PR DESCRIPTION
## Description

Adding the packaging of luaSQL-MySQL for el8 and el9 : needed by an evolution of the stream connectors library for #280.
Not needed for Debian and Ubuntu (available on official repos).

Add the ability to get packages as artifacts by adding the label upload-artifacts to the PR.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
