### PR TITLE
new(scripts): add opentelemetry otelhttp script for metrics

### DIFF
--- a/community-powered/opentelemetry/opentelemetry-otelhttp-json-metrics-apiv2.lua
+++ b/community-powered/opentelemetry/opentelemetry-otelhttp-json-metrics-apiv2.lua
@@ -1,0 +1,481 @@
+#!/usr/bin/lua
+--------------------------------------------------------------------------------
+-- Centreon Broker OpenTelemetry OTLP/HTTP JSON Encoding Connector Metrics
+--------------------------------------------------------------------------------
+
+
+-- Libraries
+local curl = require "cURL"
+local sc_common = require("centreon-stream-connectors-lib.sc_common")
+local sc_logger = require("centreon-stream-connectors-lib.sc_logger")
+local sc_broker = require("centreon-stream-connectors-lib.sc_broker")
+local sc_event = require("centreon-stream-connectors-lib.sc_event")
+local sc_params = require("centreon-stream-connectors-lib.sc_params")
+local sc_macros = require("centreon-stream-connectors-lib.sc_macros")
+local sc_flush = require("centreon-stream-connectors-lib.sc_flush")
+local sc_metrics = require("centreon-stream-connectors-lib.sc_metrics")
+
+--------------------------------------------------------------------------------
+-- Classe event_queue
+--------------------------------------------------------------------------------
+
+local EventQueue = {}
+EventQueue.__index = EventQueue
+
+local scope_name = "opentelemetry-otelhttp-json-metrics-apiv2.lua"
+local scope_version = "1.0.0"
+
+--------------------------------------------------------------------------------
+---- Constructor
+---- @param conf The table given by the init() function and returned from the GUI
+---- @return the new EventQueue
+----------------------------------------------------------------------------------
+
+function EventQueue.new(params)
+  local self = {}
+
+  local mandatory_parameters = {
+    "endpoint"
+  }
+
+  self.fail = false
+
+  -- set up log configuration
+  local logfile = params.logfile or "/var/log/centreon-broker/opentelemetry-otelhttp-json-metrics.log"
+  local log_level = params.log_level or 3
+
+  -- initiate mandatory objects
+  self.sc_logger = sc_logger.new(logfile, log_level)
+  self.sc_common = sc_common.new(self.sc_logger)
+  self.sc_broker = sc_broker.new(self.sc_logger)
+  self.sc_params = sc_params.new(self.sc_common, self.sc_logger)
+
+  -- checking mandatory parameters and setting a fail flag
+  if not self.sc_params:is_mandatory_config_set(mandatory_parameters, params) then
+    self.fail = true
+  end
+
+  --params.max_buffer_size = 1
+
+  -- overriding default parameters for this stream connector if the default values doesn't suit the basic needs
+  self.sc_params.params.endpoint = params.endpoint
+  self.sc_params.params.endpoint_uri = params.endpoint_uri or "/v1/metrics"
+  self.sc_params.params.accepted_categories = params.accepted_categories or "neb"
+  self.sc_params.params.accepted_elements = params.accepted_elements or "service_status"
+  self.sc_params.params.max_buffer_size = params.max_buffer_size or 30
+  self.sc_params.params.max_all_queues_age = params.max_all_queues_age or 10
+  self.sc_params.params.hard_only = params.hard_only or 0
+  self.sc_params.params.send_mixed_events = params.send_mixed_events or 1
+  self.sc_params.params.enable_host_status_dedup = params.enable_host_status_dedup or 0
+  self.sc_params.params.enable_service_status_dedup = params.enable_service_status_dedup or 0
+  self.sc_params.params.metric_name_regex = params.metric_name_regex or "[^a-zA-Z0-9_%.]"
+  self.sc_params.params.metric_replacement_character = params.metric_replacement_character or "_" 
+
+  -- apply users params and check syntax of standard ones
+  self.sc_params:param_override(params)
+  self.sc_params:check_params()
+  self.sc_macros = sc_macros.new(self.sc_params.params, self.sc_logger)
+
+  -- only load the custom code file, not executed yet
+  if self.sc_params.load_custom_code_file and not self.sc_params:load_custom_code_file(self.sc_params.params.custom_code_file) then
+    self.sc_logger:error("[EventQueue:new]: couldn't successfully load the custom code file: " .. tostring(self.sc_params.params.custom_code_file))
+  end
+
+  self.sc_params:build_accepted_elements_info()
+  self.sc_flush = sc_flush.new(self.sc_params.params, self.sc_logger)
+
+  local categories = self.sc_params.params.bbdo.categories
+  local elements = self.sc_params.params.bbdo.elements
+
+  self.format_event = {
+    [categories.neb.id] = {
+      [elements.host_status.id] = function () return self:format_event_host() end,
+      [elements.service_status.id] = function () return self:format_event_service() end
+    }
+  }
+
+  self.format_metric = {
+    [categories.neb.id] = {
+      [elements.host_status.id] = function (metric) return self:format_metric_host(metric) end,
+      [elements.service_status.id] = function (metric) return self:format_metric_service(metric) end
+    }
+  }
+
+  self.send_data_method = {
+    [1] = function (payload, queue_metadata) return self:send_data(payload, queue_metadata) end
+  }
+
+  self.build_payload_method = {
+    [1] = function (payload, event) return self:build_payload(payload, event) end
+  }
+
+  -- return EventQueue object
+  setmetatable(self, { __index = EventQueue })
+  return self
+end
+
+--------------------------------------------------------------------------------
+---- EventQueue:format_accepted_event method
+--------------------------------------------------------------------------------
+function EventQueue:format_accepted_event()
+  local category = self.sc_event.event.category
+  local element = self.sc_event.event.element
+
+  self.sc_logger:debug("[EventQueue:format_event]: starting format event")
+
+  -- can't format event if stream connector is not handling this kind of event and that it is not handled with a template file
+  if not self.format_event[category][element] then
+    self.sc_logger:error("[format_event]: You are trying to format an event with category: "
+      .. tostring(self.sc_params.params.reverse_category_mapping[category]) .. " and element: "
+      .. tostring(self.sc_params.params.reverse_element_mapping[category][element])
+      .. ". If it is a not a misconfiguration, you should create a format file to handle this kind of element")
+  else
+    self.format_event[category][element]()
+  end
+
+  self.sc_logger:debug("[EventQueue:format_event]: event formatting is finished")
+end
+
+--------------------------------------------------------------------------------
+---- EventQueue:format_event_host method
+--------------------------------------------------------------------------------
+function EventQueue:format_event_host()
+  local event = self.sc_event.event
+  self.sc_logger:debug("[EventQueue:format_event_host]: call build_metric ")
+  self.sc_metrics:build_metric(self.format_metric[event.category][event.element])
+end
+
+--------------------------------------------------------------------------------
+---- EventQueue:format_event_service method
+--------------------------------------------------------------------------------
+function EventQueue:format_event_service()
+  self.sc_logger:debug("[EventQueue:format_event_service]: call build_metric ")
+  local event = self.sc_event.event
+  self.sc_metrics:build_metric(self.format_metric[event.category][event.element])
+end
+
+--------------------------------------------------------------------------------
+---- EventQueue:format_metric_host method
+-- @param metric {table} a single metric data
+--------------------------------------------------------------------------------
+function EventQueue:format_metric_host(metric)
+  self.sc_logger:debug("[EventQueue:format_metric_host]: call format_metric ")
+  self:format_metric_event(metric)
+end
+
+--------------------------------------------------------------------------------
+---- EventQueue:format_metric_service method
+-- @param metric {table} a single metric data
+--------------------------------------------------------------------------------
+function EventQueue:format_metric_service(metric)
+  self.sc_logger:debug("[EventQueue:format_metric_service]: call format_metric ")
+  self:format_metric_event(metric)
+end
+
+--------------------------------------------------------------------------------
+---- EventQueue:format_metric_service method
+-- @param metric {table} a single metric data
+--------------------------------------------------------------------------------
+function EventQueue:format_metric_event(metric)
+  self.sc_logger:debug("[EventQueue:format_metric]: start real format metric ")
+  local event = self.sc_event.event
+  self.sc_event.event.formated_event = {
+    host = tostring(event.cache.host.name),
+    metric = metric.metric_name,
+    point = {
+      asDouble = metric.value,
+      timeUnixNano = event.last_check .. "000000000"
+    }
+  }
+
+  self:add()
+end
+
+--------------------------------------------------------------------------------
+-- EventQueue:add, add an event to the sending queue
+--------------------------------------------------------------------------------
+function EventQueue:add()
+  -- store event in self.events lists
+  local category = self.sc_event.event.category
+  local element = self.sc_event.event.element
+
+  self.sc_logger:debug("[EventQueue:add]: add event in queue category: " .. tostring(self.sc_params.params.reverse_category_mapping[category])
+    .. " element: " .. tostring(self.sc_params.params.reverse_element_mapping[category][element]))
+
+  self.sc_logger:debug("[EventQueue:add]: queue size before adding event: " .. tostring(#self.sc_flush.queues[category][element].events))
+  self.sc_flush.queues[category][element].events[#self.sc_flush.queues[category][element].events + 1] = self.sc_event.event.formated_event
+
+  self.sc_logger:info("[EventQueue:add]: queue size is now: " .. tostring(#self.sc_flush.queues[category][element].events) 
+    .. ", max is: " .. tostring(self.sc_params.params.max_buffer_size))
+end
+
+--------------------------------------------------------------------------------
+---- EventQueue:build_resource_attributes method
+-- @param host {string} hostname string used as a resource attribute
+-- @return attributes {table} a table representing the resource attributes
+-- See https://opentelemetry.io/docs/specs/otel/overview/#resources
+--------------------------------------------------------------------------------
+function EventQueue:build_resource_attributes(host)
+  local attributes = {}
+
+  table.insert(attributes,
+    {
+      key = "host.name",
+      value = {
+        stringValue = host
+      }
+    }
+  )
+
+  return attributes
+end
+
+--------------------------------------------------------------------------------
+---- EventQueue:build_scopemetrics method
+-- @return scopemetrics {table} a table representing the scopemetrics entry
+-- See https://opentelemetry.io/docs/specs/otel/common/instrumentation-scope/
+--------------------------------------------------------------------------------
+function EventQueue:build_scopemetrics()
+  local scopemetrics = {}
+
+  table.insert(scopemetrics, {
+      scope = {
+        name = scope_name,
+        version = scope_version
+      },
+      metrics = {}
+    }
+  )
+
+  return scopemetrics
+end
+
+--------------------------------------------------------------------------------
+---- EventQueue:build_metrics method
+-- @param metric {string} metric name
+-- @param point {table} table of data points
+-- @return metrics {table} a table representing a metric entry
+-- See https://opentelemetry.io/docs/specs/otel/metrics/data-model/#opentelemetry-protocol-data-model
+--------------------------------------------------------------------------------
+function EventQueue:build_metrics(metric, point)
+  local metrics = {}
+
+  metrics = {
+    name = metric,
+    gauge = {
+      dataPoints = {}
+    }
+  }
+  
+  table.insert(metrics.gauge.dataPoints, point)
+
+  return metrics
+end
+
+--------------------------------------------------------------------------------
+-- EventQueue:build_payload, concatenate data so it is ready to be sent
+-- @param payload {string} payload lua object
+-- @param event {table} the event that is going to be added to the payload
+-- @return payload {string} payload lua object
+-- See https://github.com/open-telemetry/opentelemetry-proto/tree/main/examples for example
+--------------------------------------------------------------------------------
+function EventQueue:build_payload(payload, event)
+  self.sc_logger:debug("[EventQueue:build_payload]: Loading event:")
+  self.sc_logger:debug("[EventQueue:build_payload]:    host: " .. event.host)
+  self.sc_logger:debug("[EventQueue:build_payload]:    metric: " .. event.metric)
+  self.sc_logger:debug("[EventQueue:build_payload]:    point value: " .. event.point.asDouble)
+  self.sc_logger:debug("[EventQueue:build_payload]:    point time: " .. event.point.timeUnixNano)
+
+  if not payload or self.indexes[event.host] == nil or self.indexes[event.host] == "" then
+    self.sc_logger:debug("[EventQueue:build_payload]: Creating resource entry for host " .. event.host .. " and metric " .. event.metric)
+    if not payload then
+      self.indexes = {}
+  
+      payload = {
+        resourceMetrics = {}
+      }
+    end
+
+    local resource_metric = {}
+    resource_metric = {
+      resource = {
+        attributes = self:build_resource_attributes(event.host)
+      },
+      scopeMetrics = self:build_scopemetrics()
+    }
+
+    table.insert(resource_metric.scopeMetrics[1].metrics, self:build_metrics(event.metric, event.point))
+    table.insert(payload.resourceMetrics, resource_metric)
+
+    self.indexes[event.host] = {}
+    self.indexes[event.host] = {
+      index = (#payload.resourceMetrics),
+      [event.metric] = 1
+    }
+  elseif self.indexes[event.host][event.metric] == nil or self.indexes[event.host][event.metric] == "" then
+    self.sc_logger:debug("[EventQueue:build_payload]: Reusing resource entry for host " .. event.host .. " and creating metric " .. event.metric)
+    table.insert(payload.resourceMetrics[self.indexes[event.host].index].scopeMetrics[1].metrics, self:build_metrics(event.metric, event.point))
+    self.indexes[event.host][event.metric] = (#payload.resourceMetrics[self.indexes[event.host].index].scopeMetrics[1].metrics)
+  else
+    self.sc_logger:debug("[EventQueue:build_payload]: Adding data points for host " .. event.host .. " and metric " .. event.metric)
+    table.insert(payload.resourceMetrics[self.indexes[event.host].index].scopeMetrics[1].metrics[self.indexes[event.host][event.metric]].gauge.dataPoints, event.point)
+  end
+
+  return payload
+end
+
+function EventQueue:send_data(payload, queue_metadata)
+  self.sc_logger:debug("[EventQueue:send_data]: Starting to send data")
+
+  local url = self.sc_params.params.endpoint .. tostring(self.sc_params.params.endpoint_uri)
+  local payload_json = broker.json_encode(payload)
+  queue_metadata.headers = {
+    "Content-Type: application/json"
+  }
+
+  self.sc_logger:log_curl_command(url, queue_metadata, self.sc_params.params, payload_json)
+
+  -- write payload in the logfile for test purpose
+  if self.sc_params.params.send_data_test == 1 then
+    self.sc_logger:notice("[send_data]: " .. tostring(payload_json))
+    return true
+  end
+
+  self.sc_logger:info("[EventQueue:send_data]: Going to send the following json " .. tostring(payload_json))
+  self.sc_logger:info("[EventQueue:send_data]: OpenTelemetry endpoint is: " .. tostring(url))
+
+  local http_response_body = ""
+  local http_request = curl.easy()
+    :setopt_url(url)
+    :setopt_writefunction(
+      function (response)
+        http_response_body = http_response_body .. tostring(response)
+      end
+    )
+    :setopt(curl.OPT_TIMEOUT, self.sc_params.params.connection_timeout)
+    :setopt(curl.OPT_SSL_VERIFYPEER, self.sc_params.params.verify_certificate)
+    :setopt(curl.OPT_HTTPHEADER, queue_metadata.headers)
+
+  -- set proxy address configuration
+  if (self.sc_params.params.proxy_address ~= '') then
+    if (self.sc_params.params.proxy_port ~= '') then
+      http_request:setopt(curl.OPT_PROXY, self.sc_params.params.proxy_address .. ':' .. self.sc_params.params.proxy_port)
+    else
+      self.sc_logger:error("[EventQueue:send_data]: proxy_port parameter is not set but proxy_address is used")
+    end
+  end
+
+  -- set proxy user configuration
+  if (self.sc_params.params.proxy_username ~= '') then
+    if (self.sc_params.params.proxy_password ~= '') then
+      http_request:setopt(curl.OPT_PROXYUSERPWD, self.sc_params.params.proxy_username .. ':' .. self.sc_params.params.proxy_password)
+    else
+      self.sc_logger:error("[EventQueue:send_data]: proxy_password parameter is not set but proxy_username is used")
+    end
+  end
+
+  -- adding the HTTP POST data
+  http_request:setopt_postfields(payload_json)
+
+  -- performing the HTTP request
+  http_request:perform()
+
+  -- collecting results
+  http_response_code = http_request:getinfo(curl.INFO_RESPONSE_CODE)
+
+  http_request:close()
+
+  -- Handling the return code
+  local retval = false
+  -- 
+  if http_response_code == 200 then
+    self.sc_logger:info("[EventQueue:send_data]: HTTP POST request successful: return code is " .. tostring(http_response_code))
+    retval = true
+  else
+    self.sc_logger:error("[EventQueue:send_data]: HTTP POST request FAILED, return code is " .. tostring(http_response_code) .. ". Message is: " .. tostring(http_response_body))
+
+    if payload then
+      self.sc_logger:error("[EventQueue:send_data]: sent payload was: " .. tostring(payload))
+    end
+  end
+
+  return retval
+end
+
+--------------------------------------------------------------------------------
+-- Required functions for Broker StreamConnector
+--------------------------------------------------------------------------------
+
+local queue
+
+-- Fonction init()
+function init(conf)
+  queue = EventQueue.new(conf)
+end
+
+-- --------------------------------------------------------------------------------
+-- write,
+-- @param {table} event, the event from broker
+-- @return {boolean}
+--------------------------------------------------------------------------------
+function write (event)
+  -- skip event if a mandatory parameter is missing
+  if queue.fail then
+    queue.sc_logger:error("Skipping event because a mandatory parameter is not set")
+    return false
+  end
+
+  -- initiate event object
+  queue.sc_metrics = sc_metrics.new(event, queue.sc_params.params, queue.sc_common, queue.sc_broker, queue.sc_logger)
+  queue.sc_event = queue.sc_metrics.sc_event
+
+  if queue.sc_event:is_valid_category() then
+    if queue.sc_metrics:is_valid_bbdo_element() then
+      -- format event if it is validated
+      if queue.sc_metrics:is_valid_metric_event() then
+        queue:format_accepted_event()
+      end
+  --- log why the event has been dropped
+    else
+      queue.sc_logger:debug("dropping event because element is not valid. Event element is: "
+        .. tostring(queue.sc_params.params.reverse_element_mapping[queue.sc_event.event.category][queue.sc_event.event.element]))
+    end
+  else
+    queue.sc_logger:debug("dropping event because category is not valid. Event category is: "
+      .. tostring(queue.sc_params.params.reverse_category_mapping[queue.sc_event.event.category]))
+  end
+
+  return flush()
+end
+
+
+-- flush method is called by broker every now and then (more often when broker has nothing else to do)
+function flush()
+  local queues_size = queue.sc_flush:get_queues_size()
+
+  -- nothing to flush
+  if queues_size == 0 then
+    return true
+  end
+
+  -- flush all queues because last global flush is too old
+  if queue.sc_flush.last_global_flush < os.time() - queue.sc_params.params.max_all_queues_age then
+    if not queue.sc_flush:flush_all_queues(queue.build_payload_method[1], queue.send_data_method[1]) then
+      return false
+    end
+
+    return true
+  end
+
+  -- flush queues because too many events are stored in them
+  if queues_size > queue.sc_params.params.max_buffer_size then
+    if not queue.sc_flush:flush_all_queues(queue.build_payload_method[1], queue.send_data_method[1]) then
+      return false
+    end
+
+    return true
+  end
+
+  -- there are events in the queue but they were not ready to be send
+  return false
+end


### PR DESCRIPTION
## Description

Adds a script to push metrics using the OpenTelemetry protocol on HTTP to a compatible backend.

The script respects the protocol as described in the following example:
https://github.com/open-telemetry/opentelemetry-proto/blob/main/examples/metrics.json

All metrics are considered gauge as per the [data model](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#opentelemetry-protocol-data-model).

Only the host.name resource attribute is added as a default. An enhancement could be to provide attributes as input from the configuration.

The configuration is thus simple:
![image](https://github.com/user-attachments/assets/c254f553-fe08-47bc-b0ee-cb1421d261d7)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

1. Build yourself a Grafana LGTM stack,
2. Configure your Broker to stream data to the Mimir/Prometheus otelhttp listener.

You should see logs like:

```
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]: Loading event:
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    host: Host-Prod
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    metric: rtmin
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    point value: 0.0070000002160668
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    point time: 1751291066000000000
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]: Creating resource entry for host Host-Prod and metric rtmin
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]: Loading event:
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    host: Host-Prod
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    metric: rta
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    point value: 0.014000000432134
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    point time: 1751291066000000000
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]: Reusing resource entry for host Host-Prod and creating metric rta
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]: Loading event:
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    host: Host-Prod
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    metric: pl
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    point value: 0.0
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    point time: 1751291066000000000
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]: Reusing resource entry for host Host-Prod and creating metric pl
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]: Loading event:
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    host: Host-Prod
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    metric: rtmax
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    point value: 0.035000000149012
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]:    point time: 1751291066000000000
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:build_payload]: Reusing resource entry for host Host-Prod and creating metric rtmax
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:send_data]: Starting to send data
Mon Jun 30 15:44:30 2025: INFO: [sc_logger:log_curl_command]: curl command not logged because log_curl_commands param is set to: 0
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:send_data]: Going to send the following json {"resourceMetrics":[{"resource":{"attributes":[{"key":"host.name","value":{"stringValue":"Host-Prod"}}]},"scopeMetrics":[{"scope":{"name":"opentelemetry-otelhttp-json-metrics-apiv2.lua","version":"1.0.0"},"metrics":[{"name":"rtmin","gauge":{"dataPoints":[{"asDouble":0.0070000002160668,"timeUnixNano":"1751291066000000000"}]}},{"name":"rta","gauge":{"dataPoints":[{"asDouble":0.014000000432134,"timeUnixNano":"1751291066000000000"}]}},{"name":"pl","gauge":{"dataPoints":[{"asDouble":0.0,"timeUnixNano":"1751291066000000000"}]}},{"name":"rtmax","gauge":{"dataPoints":[{"asDouble":0.035000000149012,"timeUnixNano":"1751291066000000000"}]}}]}]}]}
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:send_data]: OpenTelemetry endpoint is: http://10.1.2.3:4319/v1/metrics
Mon Jun 30 15:44:30 2025: INFO: [EventQueue:send_data]: HTTP POST request successful: return code is 200
```

And you should find metrics like so in the drilldown:

![streamconnector_otel_grafana](https://github.com/user-attachments/assets/0a6eebbd-0b72-41cb-9772-a2f5d37159ae)


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
