### PR TITLE
enh(flush): reduce log when queue is empty and broker don't send new messages

### DIFF
--- a/modules/centreon-stream-connectors-lib/sc_flush.lua
+++ b/modules/centreon-stream-connectors-lib/sc_flush.lua
@@ -166,9 +166,11 @@ function ScFlush:get_queues_size()
 
   for _, element_info in pairs(self.params.accepted_elements_info) do
     queues_size = queues_size + #self.queues[element_info.category_id][element_info.element_id].events
-    self.sc_logger:debug("[sc_flush:get_queues_size]: size of queue for category " .. tostring(element_info.category_name)
-      .. " and element: " .. tostring(element_info.element_name)
-      .. " is: " .. tostring(#self.queues[element_info.category_id][element_info.element_id].events))
+    if #self.queues[element_info.category_id][element_info.element_id].events > 0 then
+        self.sc_logger:debug("[sc_flush:get_queues_size]: size of queue for category " .. tostring(element_info.category_name)
+            .. " and element: " .. tostring(element_info.element_name)
+            .. " is: " .. tostring(#self.queues[element_info.category_id][element_info.element_id].events))
+    end
   end
 
   return queues_size


### PR DESCRIPTION
## Description

Reduce logging to not log queue status if queue is empty.

**Fixes** # (issue)
CTOR-2483

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [X] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
