### PR TITLE
add curl.OPT_SSL_VERIFYHOST option

### DIFF
--- a/centreon-certified/splunk/splunk-metrics-apiv2.lua
+++ b/centreon-certified/splunk/splunk-metrics-apiv2.lua
@@ -359,6 +359,7 @@ function EventQueue:send_data(payload, queue_metadata)
     )
     :setopt(curl.OPT_TIMEOUT, self.sc_params.params.connection_timeout)
     :setopt(curl.OPT_SSL_VERIFYPEER, self.sc_params.params.verify_certificate)
+    :setopt(curl.OPT_SSL_VERIFYHOST, self.sc_params.params.verify_certificate)
     :setopt(curl.OPT_HTTPHEADER, queue_metadata.headers)
 
   -- set proxy address configuration


### PR DESCRIPTION
## Description

If Splunk is provided internally as a test system with a self-signed certificate, the option “verify_certificate = 0” is currently not sufficient. Although setting log_curl_commands = 1 causes curl to be output correctly with “-k” and this curl also works correctly, the stream connector fails.

The reason is that only :setopt(curl.OPT_SSL_VERIFYPEER, self.sc_params.params.verify_certificate) is set and not VERIFYHOST.

The simple fix is to set VERIFYHOST, too.

https://github.com/centreon/centreon-stream-connector-scripts/issues/310

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

U don't need an splunk enviroment. U just need a simple server.js with a self signed certificate that logs the post requests to disk.


[server.js.txt](https://github.com/user-attachments/files/23850457/server.js.txt)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
