### PR TITLE
fix(lua-cffi): wrong version of libffi dependency

### DIFF
--- a/.github/actions/deb-delivery/action.yml
+++ b/.github/actions/deb-delivery/action.yml
@@ -36,10 +36,14 @@ runs:
 
     - if: ${{ ! (inputs.distrib == 'jammy' && inputs.stability == 'stable') }}
       name: Publish DEBs
+      env:
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
       run: |
         FILES="*.deb"
 
-        if [[ "${{ inputs.distrib }}" == "jammy" ]]; then
+        if [[ "$DISTRIB" == "jammy" ]]; then
           REPO_PREFIX="ubuntu"
         else
           REPO_PREFIX="apt"
@@ -50,6 +54,6 @@ runs:
 
           ARCH=$(echo $FILE | cut -d '_' -f3 | cut -d '.' -f1)
 
-          jf rt upload "$FILE" "${REPO_PREFIX}-plugins-${{ inputs.stability }}/pool/${{ inputs.module_name }}/" --deb "${{ inputs.distrib }}/main/$ARCH"
+          jf rt upload "$FILE" "${REPO_PREFIX}-plugins-$STABILITY/pool/$MODULE_NAME/" --deb "$DISTRIB/main/$ARCH"
         done
       shell: bash

--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -70,13 +70,13 @@ runs:
         export ARCH="$INPUT_ARCH"
 
         if [ "$INPUT_PACKAGE_EXTENSION" = "rpm" ]; then
-          export DIST=".$INPUT_DISTRIB"
+          export DIST=".${INPUT_DISTRIB}"
         else
           export DIST=""
           if [ "$INPUT_STABILITY" = "unstable" ] || [ "$INPUT_STABILITY" = "canary" ]; then
-            export RELEASE="$RELEASE~$INPUT_DISTRIB"
+            export RELEASE="${RELEASE}~${INPUT_DISTRIB}"
           else
-            export RELEASE="1~$INPUT_DISTRIB"
+            export RELEASE="1~${INPUT_DISTRIB}"
           fi
         fi
 
@@ -96,8 +96,8 @@ runs:
           BASENAME=$(basename $FILE)
           cd $DIRNAME
           sed -i "s/@luaver@/$luaver/g" $BASENAME
-          sed -i "s/@COMMIT_HASH@/$INPUT_COMMIT_HASH/g" $BASENAME
-          nfpm package --config $BASENAME --packager $INPUT_PACKAGE_EXTENSION
+          sed -i "s/@COMMIT_HASH@/${INPUT_COMMIT_HASH}/g" $BASENAME
+          nfpm package --config "$BASENAME" --packager "$INPUT_PACKAGE_EXTENSION"
           cd -
           mv $DIRNAME/*.$INPUT_PACKAGE_EXTENSION ./
         done
@@ -118,9 +118,9 @@ runs:
         INPUT_DISTRIB: ${{ inputs.distrib }}
       run: |
         if [ -z "$INPUT_ARTIFACT_NAME" ]; then
-          echo "artifact_name=packages-$INPUT_DISTRIB" >> $GITHUB_OUTPUT
+          echo "artifact_name=packages-${INPUT_DISTRIB}" >> "$GITHUB_OUTPUT"
         else
-          echo "artifact_name=$INPUT_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+          echo "artifact_name=${INPUT_ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
         fi
       shell: bash
 

--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -56,19 +56,27 @@ runs:
       env:
         RPM_GPG_SIGNING_KEY_ID: ${{ inputs.rpm_gpg_signing_key_id }}
         RPM_GPG_SIGNING_PASSPHRASE: ${{ inputs.rpm_gpg_signing_passphrase }}
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_RELEASE: ${{ inputs.release }}
+        INPUT_ARCH: ${{ inputs.arch }}
+        INPUT_PACKAGE_EXTENSION: ${{ inputs.package_extension }}
+        INPUT_DISTRIB: ${{ inputs.distrib }}
+        INPUT_STABILITY: ${{ inputs.stability }}
+        INPUT_NFPM_FILE_PATTERN: ${{ inputs.nfpm_file_pattern }}
+        INPUT_COMMIT_HASH: ${{ inputs.commit_hash }}
       run: |
-        export VERSION="${{ inputs.version }}"
-        export RELEASE="${{ inputs.release }}"
-        export ARCH="${{ inputs.arch }}"
+        export VERSION="$INPUT_VERSION"
+        export RELEASE="$INPUT_RELEASE"
+        export ARCH="$INPUT_ARCH"
 
-        if  [ "${{ inputs.package_extension }}" = "rpm" ]; then
-          export DIST=".${{ inputs.distrib }}"
+        if [ "$INPUT_PACKAGE_EXTENSION" = "rpm" ]; then
+          export DIST=".$INPUT_DISTRIB"
         else
           export DIST=""
-          if [ "${{ inputs.stability }}" = "unstable" ] || [ "${{ inputs.stability }}" = "canary" ]; then
-            export RELEASE="$RELEASE~${{ inputs.distrib }}"
+          if [ "$INPUT_STABILITY" = "unstable" ] || [ "$INPUT_STABILITY" = "canary" ]; then
+            export RELEASE="$RELEASE~$INPUT_DISTRIB"
           else
-            export RELEASE="1~${{ inputs.distrib }}"
+            export RELEASE="1~$INPUT_DISTRIB"
           fi
         fi
 
@@ -83,15 +91,15 @@ runs:
         export RPM_SIGNING_KEY_ID="$RPM_GPG_SIGNING_KEY_ID"
         export NFPM_RPM_PASSPHRASE="$RPM_GPG_SIGNING_PASSPHRASE"
 
-        for FILE in ${{ inputs.nfpm_file_pattern }}; do
+        for FILE in $INPUT_NFPM_FILE_PATTERN; do
           DIRNAME=$(dirname $FILE)
           BASENAME=$(basename $FILE)
           cd $DIRNAME
           sed -i "s/@luaver@/$luaver/g" $BASENAME
-          sed -i "s/@COMMIT_HASH@/${{ inputs.commit_hash }}/g" $BASENAME
-          nfpm package --config $BASENAME --packager ${{ inputs.package_extension }}
+          sed -i "s/@COMMIT_HASH@/$INPUT_COMMIT_HASH/g" $BASENAME
+          nfpm package --config $BASENAME --packager $INPUT_PACKAGE_EXTENSION
           cd -
-          mv $DIRNAME/*.${{ inputs.package_extension }} ./
+          mv $DIRNAME/*.$INPUT_PACKAGE_EXTENSION ./
         done
       shell: bash
 
@@ -105,11 +113,14 @@ runs:
     - if: ${{ contains(github.event.pull_request.labels.*.name, 'upload-artifacts') }}
       name: Get artifact name
       id: get-artifact-name
+      env:
+        INPUT_ARTIFACT_NAME: ${{ inputs.artifact_name }}
+        INPUT_DISTRIB: ${{ inputs.distrib }}
       run: |
-        if [ -z "${{ inputs.artifact_name }}" ]; then
-          echo "artifact_name=packages-${{ inputs.distrib }}" >> $GITHUB_OUTPUT
+        if [ -z "$INPUT_ARTIFACT_NAME" ]; then
+          echo "artifact_name=packages-$INPUT_DISTRIB" >> $GITHUB_OUTPUT
         else
-          echo "artifact_name=${{ inputs.artifact_name }}" >> $GITHUB_OUTPUT
+          echo "artifact_name=$INPUT_ARTIFACT_NAME" >> $GITHUB_OUTPUT
         fi
       shell: bash
 

--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -33,17 +33,21 @@ runs:
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
 
     - name: Publish RPMs
+      env:
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
       run: |
         FILES="*.rpm"
 
-        echo "[DEBUG] - Distrib: ${{ inputs.distrib }}"
+        echo "[DEBUG] - Distrib: $DISTRIB"
 
-        if [ -z "${{ inputs.module_name }}" ]; then
+        if [ -z "$MODULE_NAME" ]; then
           echo "module name is required"
           exit 1
         fi
 
-        if [ -z "${{ inputs.distrib }}" ]; then
+        if [ -z "$DISTRIB" ]; then
           echo "distrib is required"
           exit 1
         fi
@@ -62,10 +66,10 @@ runs:
 
         for ARCH in "noarch" "x86_64"; do
           if [ "$(ls -A $ARCH)" ]; then
-            if [ "${{ inputs.stability }}" == "stable" ]; then
-              jf rt upload "$ARCH/*.rpm" "rpm-plugins/${{ inputs.distrib }}/${{ inputs.stability }}/$ARCH/RPMS/${{ inputs.module_name }}/" --flat
+            if [ "$STABILITY" == "stable" ]; then
+              jf rt upload "$ARCH/*.rpm" "rpm-plugins/$DISTRIB/$STABILITY/$ARCH/RPMS/$MODULE_NAME/" --flat
             else
-              jf rt upload "$ARCH/*.rpm" "rpm-plugins/${{ inputs.distrib }}/${{ inputs.stability }}/$ARCH/${{ inputs.module_name }}/" --flat
+              jf rt upload "$ARCH/*.rpm" "rpm-plugins/$DISTRIB/$STABILITY/$ARCH/$MODULE_NAME/" --flat
             fi
           fi
         done

--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -67,9 +67,9 @@ runs:
         for ARCH in "noarch" "x86_64"; do
           if [ "$(ls -A $ARCH)" ]; then
             if [ "$STABILITY" == "stable" ]; then
-              jf rt upload "$ARCH/*.rpm" "rpm-plugins/$DISTRIB/$STABILITY/$ARCH/RPMS/$MODULE_NAME/" --flat
+              jf rt upload "${ARCH}/*.rpm" "rpm-plugins/${DISTRIB}/${STABILITY}/${ARCH}/RPMS/${MODULE_NAME}/" --flat
             else
-              jf rt upload "$ARCH/*.rpm" "rpm-plugins/$DISTRIB/$STABILITY/$ARCH/$MODULE_NAME/" --flat
+              jf rt upload "${ARCH}/*.rpm" "rpm-plugins/${DISTRIB}/${STABILITY}/${ARCH}/${MODULE_NAME}/" --flat
             fi
           fi
         done

--- a/.github/actions/test-packages/action.yml
+++ b/.github/actions/test-packages/action.yml
@@ -7,6 +7,9 @@ inputs:
   distrib:
     description: "The distribution name"
     required: true
+  cache_key:
+    description: "The cache key to restore packages"
+    required: true
 
 runs:
   using: "composite"
@@ -38,7 +41,7 @@ runs:
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ./*.${{ inputs.package_extension }}
-        key: ${{ github.sha }}-${{ github.run_id }}-${{ inputs.package_extension }}-${{ inputs.distrib }}
+        key: ${{ inputs.cache_key }}
         fail-on-cache-miss: true
 
     - if: ${{ inputs.package_extension == 'rpm' }}

--- a/.github/actions/test-packages/action.yml
+++ b/.github/actions/test-packages/action.yml
@@ -1,5 +1,5 @@
-name: "test-cpan-libs"
-description: "Test packaged CPAN libraries"
+name: "test-packages"
+description: "Test packaged Lua libraries"
 inputs:
   package_extension:
     description: "The package extension (deb or rpm)"

--- a/.github/actions/test-packages/action.yml
+++ b/.github/actions/test-packages/action.yml
@@ -46,8 +46,10 @@ runs:
 
     - if: ${{ inputs.package_extension == 'rpm' }}
       name: Check packages installation / uninstallation
+      env:
+        DISTRIB: ${{ inputs.distrib }}
       run: |
-        error_log="install_error_${{ inputs.distrib }}.log"
+        error_log="install_error_$DISTRIB.log"
         for package in ./*.rpm; do
           echo "Installing package: $package"
           # Install package, then uninstall it with all his dependencies
@@ -75,8 +77,10 @@ runs:
 
     - if: ${{ inputs.package_extension == 'deb' }}
       name: Check packages installation / uninstallation
+      env:
+        DISTRIB: ${{ inputs.distrib }}
       run: |
-        error_log="install_error_${{ inputs.distrib }}.log"
+        error_log="install_error_$DISTRIB.log"
         for package in ./*.deb; do
           echo "Installing package: $package"
           # Install package, then uninstall it with all his dependencies

--- a/.github/actions/test-packages/action.yml
+++ b/.github/actions/test-packages/action.yml
@@ -14,7 +14,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-
     - if: ${{ inputs.package_extension == 'rpm' }}
       name: Install zstd and Centreon GPG key
       run: |

--- a/.github/actions/test-packages/action.yml
+++ b/.github/actions/test-packages/action.yml
@@ -83,7 +83,7 @@ runs:
           echo "Package installation..."
           error_output=$(apt-get install -y $package 2>&1) || { echo "$error_output" >> $error_log; echo "Error during installation of the package $package" >> $error_log; true; }
           echo "Package installation done."
-          pack_name=$(echo $package | sed 's/_[0-9\.-]*~[a-z]*_.*\.deb//')
+          pack_name=$(echo $package | sed 's/\.\///' | sed 's/_[0-9\.-]*~[a-z]*_.*\.deb//')
           if [[ -f ./tests/packaging/$pack_name.lua ]]; then
               echo "Testing package..."
               error_output=$(lua tests/packaging/$pack_name.lua 2>&1) || { echo "$error_output" >> $error_log; echo "Error during the usage test of the package $package" >> $error_log; true; }

--- a/.github/actions/test-packages/action.yml
+++ b/.github/actions/test-packages/action.yml
@@ -1,0 +1,104 @@
+name: "test-cpan-libs"
+description: "Test packaged CPAN libraries"
+inputs:
+  package_extension:
+    description: "The package extension (deb or rpm)"
+    required: true
+  distrib:
+    description: "The distribution name"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+
+    - if: ${{ inputs.package_extension == 'rpm' }}
+      name: Install zstd and Centreon GPG key
+      run: |
+        dnf install -y zstd
+        # Import Centreon GPG key
+        GPG_KEY_URL="https://yum-gpg.centreon.com/RPM-GPG-KEY-CES"
+        curl -sSL $GPG_KEY_URL -o RPM-GPG-KEY-CES
+        rpm --import RPM-GPG-KEY-CES
+      shell: bash
+
+    - if: ${{ inputs.package_extension == 'deb' }}
+      name: Install zstd and Centreon GPG key
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y zstd wget gpg
+        wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
+        # Avoid apt to clean packages cache directory
+        rm -f /etc/apt/apt.conf.d/docker-clean
+        apt-get update
+      shell: bash
+
+    - name: Restore packages from cache
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ./*.${{ inputs.package_extension }}
+        key: ${{ github.sha }}-${{ github.run_id }}-${{ inputs.package_extension }}-${{ inputs.distrib }}
+        fail-on-cache-miss: true
+
+    - if: ${{ inputs.package_extension == 'rpm' }}
+      name: Check packages installation / uninstallation
+      run: |
+        error_log="install_error_${{ inputs.distrib }}_${{ inputs.arch }}.log"
+        for package in ./*.rpm; do
+          echo "Installing package: $package"
+          # Install package, then uninstall it with all his dependencies
+          echo "Package installation..."
+          error_output=$(dnf install -y $package 2>&1) || { echo "$error_output" >> $error_log; echo "Error during installation of the package $package" >> $error_log; true; }
+          echo "Package installation done."
+          pack_name=$(echo $package | sed 's/\.\///' | sed 's/-[0-9\.-]*.el[0-9]*..*.rpm//')
+          if [[ -f ./tests/packaging/$pack_name.lua ]]; then
+              echo "Testing package..."
+              error_output=$(perl tests/packaging/$pack_name.lua 2>&1) || { echo "$error_output" >> $error_log; echo "Error during the usage test of the package $package" >> $error_log; true; }
+              echo "Testing done."
+          else
+              echo "No test script found for the package $package"
+          fi
+          echo "Package uninstallation..."
+          error_output=$(dnf autoremove --setopt=keepcache=True -y $pack_name 2>&1) || { echo "$error_output" >> $error_log; echo "Error during autoremove of the package $package" >> $error_log; true; }
+          echo "Package uninstallation done."
+        done
+        # If the file error_log exists and is not empty, the workflow is in error
+        if [[ -s $error_log ]]; then
+            cat $error_log
+            exit 1
+        fi
+      shell: bash
+
+    - if: ${{ inputs.package_extension == 'deb' }}
+      name: Check packages installation / uninstallation
+      run: |
+        error_log="install_error_${{ inputs.distrib }}_${{ inputs.arch }}.log"
+        for package in ./*.deb; do
+          # If the debian package name ends with amd64 or arm64, we only install it if the tested architecture is the same, otherwise we skip it
+          if [[ $package == *amd64.deb && ${{ inputs.arch }} != "amd64" || $package == *arm64.deb && ${{ inputs.arch }} != "arm64" ]]; then
+            continue
+          fi
+          echo "Installing package: $package"
+          # Install package, then uninstall it with all his dependencies
+          echo "Package installation..."
+          error_output=$(apt-get install -y $package 2>&1) || { echo "$error_output" >> $error_log; echo "Error during installation of the package $package" >> $error_log; true; }
+          echo "Package installation done."
+          pack_name=$(echo $package | sed 's/_[0-9\.-]*~[a-z]*_.*\.deb//')
+          if [[ -f ./tests/packaging/$pack_name.lua ]]; then
+              echo "Testing package..."
+              error_output=$(lua tests/packaging/$pack_name.lua 2>&1) || { echo "$error_output" >> $error_log; echo "Error during the usage test of the package $package" >> $error_log; true; }
+              echo "Testing done."
+          else
+              echo "No test script found for the package $package"
+          fi
+          echo "Package uninstallation..."
+          error_output=$(apt-get autoremove -y --purge $pack_name || { echo "$error_output" >> $error_log; echo "Error during autoremove of the package $package" >> $error_log; true; }
+          echo "Package uninstallation done."
+        done
+        # If the file error_log exists and is not empty, the workflow is in error
+        if [[ -s $error_log ]]; then
+            cat $error_log
+            exit 1
+        fi
+      shell: bash

--- a/.github/actions/test-packages/action.yml
+++ b/.github/actions/test-packages/action.yml
@@ -21,7 +21,7 @@ runs:
         dnf install -y zstd
         # Import Centreon GPG key
         GPG_KEY_URL="https://yum-gpg.centreon.com/RPM-GPG-KEY-CES"
-        curl -sSL $GPG_KEY_URL -o RPM-GPG-KEY-CES
+        curl -sSL "$GPG_KEY_URL" -o RPM-GPG-KEY-CES
         rpm --import RPM-GPG-KEY-CES
       shell: bash
 
@@ -54,23 +54,23 @@ runs:
           echo "Installing package: $package"
           # Install package, then uninstall it with all his dependencies
           echo "Package installation..."
-          error_output=$(dnf install -y $package 2>&1) || { echo "$error_output" >> $error_log; echo "Error during installation of the package $package" >> $error_log; true; }
+          error_output=$(dnf install -y "$package" 2>&1) || { echo "$error_output" >> "$error_log"; echo "Error during installation of the package $package" >> "$error_log"; true; }
           echo "Package installation done."
-          pack_name=$(echo $package | sed 's/\.\///' | sed 's/-[0-9\.-]*.el[0-9]*..*.rpm//')
+          pack_name=$(echo "$package" | sed 's/\.\///' | sed 's/-[0-9\.-]*.el[0-9]*..*.rpm//')
           if [[ -f ./tests/packaging/$pack_name.lua ]]; then
               echo "Testing package..."
-              error_output=$(lua tests/packaging/$pack_name.lua 2>&1) || { echo "$error_output" >> $error_log; echo "Error during the usage test of the package $package" >> $error_log; true; }
+              error_output=$(lua "tests/packaging/${pack_name}.lua" 2>&1) || { echo "$error_output" >> "$error_log"; echo "Error during the usage test of the package $package" >> "$error_log"; true; }
               echo "Testing done."
           else
               echo "No test script found for the package $package"
           fi
           echo "Package uninstallation..."
-          error_output=$(dnf autoremove --setopt=keepcache=True -y $pack_name 2>&1) || { echo "$error_output" >> $error_log; echo "Error during autoremove of the package $package" >> $error_log; true; }
+          error_output=$(dnf autoremove --setopt=keepcache=True -y "$pack_name" 2>&1) || { echo "$error_output" >> "$error_log"; echo "Error during autoremove of the package $package" >> "$error_log"; true; }
           echo "Package uninstallation done."
         done
         # If the file error_log exists and is not empty, the workflow is in error
-        if [[ -s $error_log ]]; then
-            cat $error_log
+        if [[ -s "$error_log" ]]; then
+            cat "$error_log"
             exit 1
         fi
       shell: bash
@@ -80,28 +80,28 @@ runs:
       env:
         DISTRIB: ${{ inputs.distrib }}
       run: |
-        error_log="install_error_$DISTRIB.log"
+        error_log="install_error_${DISTRIB}.log"
         for package in ./*.deb; do
           echo "Installing package: $package"
           # Install package, then uninstall it with all his dependencies
           echo "Package installation..."
-          error_output=$(apt-get install -y $package 2>&1) || { echo "$error_output" >> $error_log; echo "Error during installation of the package $package" >> $error_log; true; }
+          error_output=$(apt-get install -y "$package" 2>&1) || { echo "$error_output" >> "$error_log"; echo "Error during installation of the package $package" >> "$error_log"; true; }
           echo "Package installation done."
-          pack_name=$(echo $package | sed 's/\.\///' | sed 's/_[0-9\.-]*~[a-z]*_.*\.deb//')
-          if [[ -f ./tests/packaging/$pack_name.lua ]]; then
+          pack_name=$(echo "$package" | sed 's/\.\///' | sed 's/_[0-9\.-]*~[a-z]*_.*\.deb//')
+          if [[ -f "./tests/packaging/${pack_name}.lua" ]]; then
               echo "Testing package..."
-              error_output=$(lua tests/packaging/$pack_name.lua 2>&1) || { echo "$error_output" >> $error_log; echo "Error during the usage test of the package $package" >> $error_log; true; }
+              error_output=$(lua "tests/packaging/${pack_name}.lua" 2>&1) || { echo "$error_output" >> "$error_log"; echo "Error during the usage test of the package $package" >> "$error_log"; true; }
               echo "Testing done."
           else
               echo "No test script found for the package $package"
           fi
           echo "Package uninstallation..."
-          error_output=$(apt-get autoremove -y --purge $pack_name 2>&1) || { echo "$error_output" >> $error_log; echo "Error during autoremove of the package $package" >> $error_log; true; }
+          error_output=$(apt-get autoremove -y --purge "$pack_name" 2>&1) || { echo "$error_output" >> "$error_log"; echo "Error during autoremove of the package $package" >> "$error_log"; true; }
           echo "Package uninstallation done."
         done
         # If the file error_log exists and is not empty, the workflow is in error
-        if [[ -s $error_log ]]; then
-            cat $error_log
+        if [[ -s "$error_log" ]]; then
+            cat "$error_log"
             exit 1
         fi
       shell: bash

--- a/.github/actions/test-packages/action.yml
+++ b/.github/actions/test-packages/action.yml
@@ -44,7 +44,7 @@ runs:
     - if: ${{ inputs.package_extension == 'rpm' }}
       name: Check packages installation / uninstallation
       run: |
-        error_log="install_error_${{ inputs.distrib }}_${{ inputs.arch }}.log"
+        error_log="install_error_${{ inputs.distrib }}.log"
         for package in ./*.rpm; do
           echo "Installing package: $package"
           # Install package, then uninstall it with all his dependencies
@@ -73,12 +73,8 @@ runs:
     - if: ${{ inputs.package_extension == 'deb' }}
       name: Check packages installation / uninstallation
       run: |
-        error_log="install_error_${{ inputs.distrib }}_${{ inputs.arch }}.log"
+        error_log="install_error_${{ inputs.distrib }}.log"
         for package in ./*.deb; do
-          # If the debian package name ends with amd64 or arm64, we only install it if the tested architecture is the same, otherwise we skip it
-          if [[ $package == *amd64.deb && ${{ inputs.arch }} != "amd64" || $package == *arm64.deb && ${{ inputs.arch }} != "arm64" ]]; then
-            continue
-          fi
           echo "Installing package: $package"
           # Install package, then uninstall it with all his dependencies
           echo "Package installation..."

--- a/.github/actions/test-packages/action.yml
+++ b/.github/actions/test-packages/action.yml
@@ -57,7 +57,7 @@ runs:
           pack_name=$(echo $package | sed 's/\.\///' | sed 's/-[0-9\.-]*.el[0-9]*..*.rpm//')
           if [[ -f ./tests/packaging/$pack_name.lua ]]; then
               echo "Testing package..."
-              error_output=$(perl tests/packaging/$pack_name.lua 2>&1) || { echo "$error_output" >> $error_log; echo "Error during the usage test of the package $package" >> $error_log; true; }
+              error_output=$(lua tests/packaging/$pack_name.lua 2>&1) || { echo "$error_output" >> $error_log; echo "Error during the usage test of the package $package" >> $error_log; true; }
               echo "Testing done."
           else
               echo "No test script found for the package $package"
@@ -92,7 +92,7 @@ runs:
               echo "No test script found for the package $package"
           fi
           echo "Package uninstallation..."
-          error_output=$(apt-get autoremove -y --purge $pack_name || { echo "$error_output" >> $error_log; echo "Error during autoremove of the package $package" >> $error_log; true; }
+          error_output=$(apt-get autoremove -y --purge $pack_name 2>&1) || { echo "$error_output" >> $error_log; echo "Error during autoremove of the package $package" >> $error_log; true; }
           echo "Package uninstallation done."
         done
         # If the file error_log exists and is not empty, the workflow is in error

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-alma8
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-alma8
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/almalinux:8
 

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-alma8
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-alma8
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL=docker.io
+ARG REGISTRY_URL=docker.centreon.com/centreon
 
 FROM ${REGISTRY_URL}/almalinux:8
 

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-alma9
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-alma9
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/almalinux:9
 

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-alma9
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-alma9
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL=docker.io
+ARG REGISTRY_URL=docker.centreon.com/centreon
 
 FROM ${REGISTRY_URL}/almalinux:9
 

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-bookworm
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-bookworm
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/debian:bookworm
 

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-bookworm
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-bookworm
@@ -1,11 +1,11 @@
-ARG REGISTRY_URL=docker.io
+ARG REGISTRY_URL=docker.centreon.com/centreon
 
 FROM ${REGISTRY_URL}/debian:bookworm
 
 RUN bash -e <<EOF
 
 apt-get update
-apt-get install -y git zstd ca-certificates lua5.4 liblua5.4-dev
+apt-get install -y git zstd ca-certificates lua5.3 liblua5.3-dev
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-bookworm
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-bookworm
@@ -5,7 +5,7 @@ FROM ${REGISTRY_URL}/debian:bookworm
 RUN bash -e <<EOF
 
 apt-get update
-apt-get install -y git zstd ca-certificates lua5.3 liblua5.3-dev
+apt-get install -y git zstd ca-certificates lua5.4 liblua5.4-dev
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-bullseye
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-bullseye
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/debian:bullseye
 

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-bullseye
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-bullseye
@@ -5,7 +5,7 @@ FROM ${REGISTRY_URL}/debian:bullseye
 RUN bash -e <<EOF
 
 apt-get update
-apt-get install -y git zstd ca-certificates lua5.3 liblua5.3-dev
+apt-get install -y git zstd ca-certificates lua5.4 liblua5.4-dev
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-bullseye
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-bullseye
@@ -1,11 +1,11 @@
-ARG REGISTRY_URL=docker.io
+ARG REGISTRY_URL=docker.centreon.com/centreon
 
 FROM ${REGISTRY_URL}/debian:bullseye
 
 RUN bash -e <<EOF
 
 apt-get update
-apt-get install -y git zstd ca-certificates lua5.4 liblua5.4-dev
+apt-get install -y git zstd ca-certificates lua5.3 liblua5.3-dev
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-jammy
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-jammy
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/ubuntu:jammy
 

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-jammy
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-jammy
@@ -5,7 +5,7 @@ FROM ${REGISTRY_URL}/ubuntu:jammy
 RUN bash -e <<EOF
 
 apt-get update
-apt-get install -y git zstd ca-certificates lua5.3 liblua5.3-dev
+apt-get install -y git zstd ca-certificates lua5.4 liblua5.4-dev
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-jammy
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-jammy
@@ -1,11 +1,11 @@
-ARG REGISTRY_URL=docker.io
+ARG REGISTRY_URL=docker.centreon.com/centreon
 
 FROM ${REGISTRY_URL}/ubuntu:jammy
 
 RUN bash -e <<EOF
 
 apt-get update
-apt-get install -y git zstd ca-certificates lua5.4 liblua5.4-dev
+apt-get install -y git zstd ca-certificates lua5.3 liblua5.3-dev
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 

--- a/.github/workflows/docker-packaging.yml
+++ b/.github/workflows/docker-packaging.yml
@@ -23,7 +23,7 @@ jobs:
 
   dockerize:
     needs: [dependency-scan]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   get-environment:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       stability: ${{ steps.get_environment.outputs.stability }}
 

--- a/.github/workflows/lua-cffi.yml
+++ b/.github/workflows/lua-cffi.yml
@@ -48,7 +48,7 @@ jobs:
             image: packaging-stream-connectors-nfpm-jammy
             distrib: jammy
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     container:
       image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:latest
@@ -89,10 +89,10 @@ jobs:
           cd cffi-lua-src
           mkdir build
           cd build
-          if  [ "${{ matrix.distrib }}" = "el9" ]; then
-            meson .. -Dlua_version=5.4
-          else
+          if  [[ "${{ matrix.distrib }}" = "el8" || "${{ matrix.distrib }}" = "bullseye" ]]; then
             meson .. -Dlua_version=5.3
+          else
+            meson .. -Dlua_version=5.4
           fi
           ninja all
           cd ../..
@@ -119,7 +119,7 @@ jobs:
   deliver-rpm:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
     needs: [get-environment, package]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         distrib: [el8, el9]
@@ -141,7 +141,7 @@ jobs:
   deliver-deb:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
     needs: [get-environment, package]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         distrib: [bullseye, bookworm, jammy]

--- a/.github/workflows/lua-cffi.yml
+++ b/.github/workflows/lua-cffi.yml
@@ -152,14 +152,13 @@ jobs:
         with:
           package_extension: ${{ matrix.package_extension }}
           distrib: ${{ matrix.distrib }}
-          arch: ${{ matrix.arch }}
 
       - name: Upload error log
         if: failure()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: install_error_log_${{ matrix.distrib }}-${{ matrix.arch }}
-          path: install_error_${{ matrix.distrib }}_${{ matrix.arch }}.log
+          name: install_error_log_${{ matrix.distrib }}
+          path: install_error_${{ matrix.distrib }}.log
 
   deliver-rpm:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}

--- a/.github/workflows/lua-cffi.yml
+++ b/.github/workflows/lua-cffi.yml
@@ -145,15 +145,13 @@ jobs:
           - package_extension: deb
             image: ubuntu:jammy
             distrib: jammy
-
     runs-on: ubuntu-24.04
     container:
       image: ${{ matrix.image }}
 
     name: Test lua packages on ${{ matrix.package_extension }} ${{ matrix.distrib }}
     steps:
-
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Test packaged libs
         uses: ./.github/actions/test-packages

--- a/.github/workflows/lua-cffi.yml
+++ b/.github/workflows/lua-cffi.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - dependencies/lua-cffi/**
+      - .github/workflows/lua-cffi.yml
   push:
     branches:
       - develop

--- a/.github/workflows/lua-cffi.yml
+++ b/.github/workflows/lua-cffi.yml
@@ -65,13 +65,16 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install dependencies
+        env:
+          PACKAGE_EXTENSION: ${{ matrix.package_extension }}
+          DISTRIB: ${{ matrix.distrib }}
         run: |
-          if  [ "${{ matrix.package_extension }}" = "rpm" ]; then
+          if [ "$PACKAGE_EXTENSION" = "rpm" ]; then
             dnf install -y make gcc gcc-c++ meson cmake libffi libffi-devel
           else
             apt-get update
             apt-get install -y make gcc g++ meson cmake libffi-dev
-            if [ "${{ matrix.distrib }}" = "bullseye" ]; then
+            if [ "$DISTRIB" = "bullseye" ]; then
               apt-get install -y libffi7
             else
               apt-get install -y libffi8
@@ -87,11 +90,13 @@ jobs:
           ref: "v0.2.3"
 
       - name: Prepare packaging of lua-cffi
+        env:
+          DISTRIB: ${{ matrix.distrib }}
         run: |
           cd cffi-lua-src
           mkdir build
           cd build
-          if  [[ "${{ matrix.distrib }}" = "el9" ]]; then
+          if [ "$DISTRIB" = "el9" ]; then
             meson .. -Dlua_version=5.4
           else
             meson .. -Dlua_version=5.3

--- a/.github/workflows/lua-cffi.yml
+++ b/.github/workflows/lua-cffi.yml
@@ -152,6 +152,7 @@ jobs:
         with:
           package_extension: ${{ matrix.package_extension }}
           distrib: ${{ matrix.distrib }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-lua-cffi-${{ matrix.distrib }}
 
       - name: Upload error log
         if: failure()

--- a/.github/workflows/lua-cffi.yml
+++ b/.github/workflows/lua-cffi.yml
@@ -91,10 +91,10 @@ jobs:
           cd cffi-lua-src
           mkdir build
           cd build
-          if  [[ "${{ matrix.distrib }}" = "el8" ]]; then
-            meson .. -Dlua_version=5.3
-          else
+          if  [[ "${{ matrix.distrib }}" = "el9" ]]; then
             meson .. -Dlua_version=5.4
+          else
+            meson .. -Dlua_version=5.3
           fi
           ninja all
           cd ../..

--- a/.github/workflows/lua-cffi.yml
+++ b/.github/workflows/lua-cffi.yml
@@ -117,6 +117,7 @@ jobs:
           rpm_gpg_signing_key_id: ${{ secrets.RPM_GPG_SIGNING_KEY_ID }}
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-environment.outputs.stability }}
+          artifact_name: "package-lua-cffi-${{ matrix.distrib }}"
 
   test-packages:
     needs: [get-environment, package]

--- a/.github/workflows/lua-cffi.yml
+++ b/.github/workflows/lua-cffi.yml
@@ -69,10 +69,10 @@ jobs:
           else
             apt-get update
             apt-get install -y make gcc g++ meson cmake libffi-dev
-            if [ "${{ matrix.distrib }}" = "bookworm" ]; then
-              apt-get install -y libffi8
-            else
+            if [ "${{ matrix.distrib }}" = "bullseye" ]; then
               apt-get install -y libffi7
+            else
+              apt-get install -y libffi8
             fi
           fi
         shell: bash

--- a/.github/workflows/lua-cffi.yml
+++ b/.github/workflows/lua-cffi.yml
@@ -89,7 +89,7 @@ jobs:
           cd cffi-lua-src
           mkdir build
           cd build
-          if  [[ "${{ matrix.distrib }}" = "el8" || "${{ matrix.distrib }}" = "bullseye" ]]; then
+          if  [[ "${{ matrix.distrib }}" = "el8" ]]; then
             meson .. -Dlua_version=5.3
           else
             meson .. -Dlua_version=5.4
@@ -115,6 +115,51 @@ jobs:
           rpm_gpg_signing_key_id: ${{ secrets.RPM_GPG_SIGNING_KEY_ID }}
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-environment.outputs.stability }}
+
+  test-packages:
+    needs: [get-environment, package]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package_extension: rpm
+            image: almalinux:8
+            distrib: el8
+          - package_extension: rpm
+            image: almalinux:9
+            distrib: el9
+          - package_extension: deb
+            image: debian:bullseye
+            distrib: bullseye
+          - package_extension: deb
+            image: debian:bookworm
+            distrib: bookworm
+          - package_extension: deb
+            image: ubuntu:jammy
+            distrib: jammy
+
+    runs-on: ubuntu-24.04
+    container:
+      image: ${{ matrix.image }}
+
+    name: Test lua packages on ${{ matrix.package_extension }} ${{ matrix.distrib }}
+    steps:
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Test packaged libs
+        uses: ./.github/actions/test-packages
+        with:
+          package_extension: ${{ matrix.package_extension }}
+          distrib: ${{ matrix.distrib }}
+          arch: ${{ matrix.arch }}
+
+      - name: Upload error log
+        if: failure()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: install_error_log_${{ matrix.distrib }}-${{ matrix.arch }}
+          path: install_error_${{ matrix.distrib }}_${{ matrix.arch }}.log
 
   deliver-rpm:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}

--- a/.github/workflows/lua-cffi.yml
+++ b/.github/workflows/lua-cffi.yml
@@ -8,14 +8,15 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - dependencies/lua-cffi/**
-      - .github/workflows/lua-cffi.yml
+      - '.github/workflows/lua-cffi.yml'
+      - 'dependencies/lua-cffi/**'
   push:
     branches:
       - develop
       - master
     paths:
-      - dependencies/lua-cffi/**
+      - '.github/workflows/lua-cffi.yml'
+      - 'dependencies/lua-cffi/**'
 
 jobs:
   dependency-scan:

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -76,7 +76,7 @@ jobs:
           dnf install -y make gcc lua lua-devel mysql mysql-devel
           cd lua-sql-src
           make mysql DRIVER_LIBS_mysql="-L/usr/lib64/mysql -lmysqlclient" DRIVER_INCS_mysql=-I/usr/include/mysql LUA_SYS_VER="$LUA_VERSION"
-         cd ..
+          cd ..
 
           sed -i "s/@luaver@/${LUA_VERSION}/g" dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
         shell: bash

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -128,14 +128,13 @@ jobs:
         with:
           package_extension: ${{ matrix.package_extension }}
           distrib: ${{ matrix.distrib }}
-          arch: ${{ matrix.arch }}
 
       - name: Upload error log
         if: failure()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: install_error_log_${{ matrix.distrib }}-${{ matrix.arch }}
-          path: install_error_${{ matrix.distrib }}_${{ matrix.arch }}.log
+          name: install_error_log_${{ matrix.distrib }}
+          path: install_error_${{ matrix.distrib }}.log
 
   deliver-rpm:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -8,14 +8,15 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - dependencies/lua-sql-mysql/**
+      - '.github/workflows/lua-sql-mysql.yml'
+      - 'dependencies/lua-sql-mysql/**'
   push:
     branches:
       - develop
       - master
     paths:
-      - dependencies/lua-sql-mysql/**
-      - .github/workflows/lua-sql-mysql.yml
+      - '.github/workflows/lua-sql-mysql.yml'
+      - 'dependencies/lua-sql-mysql/**'
 
 jobs:
   dependency-scan:

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -63,19 +63,22 @@ jobs:
           ref: "2.6.0"
 
       - name: Prepare packaging of lua-sql-mysql
+        env:
+          DISTRIB: ${{ matrix.distrib }}
+          LUA_VERSION: ${{ matrix.lua_version }}
         run: |
           dnf install -y dnf-plugins-core
-          if [ "${{ matrix.distrib }}" == "el8" ]; then
+          if [ "$DISTRIB" == "el8" ]; then
             dnf config-manager --set-enabled powertools
           else
             dnf config-manager --set-enabled crb
           fi
           dnf install -y make gcc lua lua-devel mysql mysql-devel
           cd lua-sql-src
-          make mysql DRIVER_LIBS_mysql="-L/usr/lib64/mysql -lmysqlclient" DRIVER_INCS_mysql=-I/usr/include/mysql LUA_SYS_VER=${{ matrix.lua_version }}
+          make mysql DRIVER_LIBS_mysql="-L/usr/lib64/mysql -lmysqlclient" DRIVER_INCS_mysql=-I/usr/include/mysql LUA_SYS_VER=$LUA_VERSION
           cd ..
 
-          sed -i "s/@luaver@/${{ matrix.lua_version }}/g" dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
+          sed -i "s/@luaver@/$LUA_VERSION/g" dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
         shell: bash
 
       - name: Package

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -117,8 +117,7 @@ jobs:
 
     name: Test lua packages on ${{ matrix.package_extension }} ${{ matrix.distrib }}
     steps:
-
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Test packaged libs
         uses: ./.github/actions/test-packages

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -15,6 +15,7 @@ on:
       - master
     paths:
       - dependencies/lua-sql-mysql/**
+      - .github/workflows/lua-sql-mysql.yml
 
 jobs:
   dependency-scan:

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -93,6 +93,7 @@ jobs:
           rpm_gpg_signing_key_id: ${{ secrets.RPM_GPG_SIGNING_KEY_ID }}
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-environment.outputs.stability }}
+          artifact_name: "package-lua-sql-mysql-${{ matrix.distrib }}"
 
   test-packages:
     needs: [get-environment, package]

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -104,15 +104,6 @@ jobs:
           - package_extension: rpm
             image: almalinux:9
             distrib: el9
-          - package_extension: deb
-            image: debian:bullseye
-            distrib: bullseye
-          - package_extension: deb
-            image: debian:bookworm
-            distrib: bookworm
-          - package_extension: deb
-            image: ubuntu:jammy
-            distrib: jammy
 
     runs-on: ubuntu-24.04
     container:
@@ -128,6 +119,7 @@ jobs:
         with:
           package_extension: ${{ matrix.package_extension }}
           distrib: ${{ matrix.distrib }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-lua-sql-mysql-${{ matrix.distrib }}
 
       - name: Upload error log
         if: failure()

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -92,6 +92,51 @@ jobs:
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-environment.outputs.stability }}
 
+  test-packages:
+    needs: [get-environment, package]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package_extension: rpm
+            image: almalinux:8
+            distrib: el8
+          - package_extension: rpm
+            image: almalinux:9
+            distrib: el9
+          - package_extension: deb
+            image: debian:bullseye
+            distrib: bullseye
+          - package_extension: deb
+            image: debian:bookworm
+            distrib: bookworm
+          - package_extension: deb
+            image: ubuntu:jammy
+            distrib: jammy
+
+    runs-on: ubuntu-24.04
+    container:
+      image: ${{ matrix.image }}
+
+    name: Test lua packages on ${{ matrix.package_extension }} ${{ matrix.distrib }}
+    steps:
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Test packaged libs
+        uses: ./.github/actions/test-packages
+        with:
+          package_extension: ${{ matrix.package_extension }}
+          distrib: ${{ matrix.distrib }}
+          arch: ${{ matrix.arch }}
+
+      - name: Upload error log
+        if: failure()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: install_error_log_${{ matrix.distrib }}-${{ matrix.arch }}
+          path: install_error_${{ matrix.distrib }}_${{ matrix.arch }}.log
+
   deliver-rpm:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
     needs: [get-environment, package]

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -75,10 +75,10 @@ jobs:
           fi
           dnf install -y make gcc lua lua-devel mysql mysql-devel
           cd lua-sql-src
-          make mysql DRIVER_LIBS_mysql="-L/usr/lib64/mysql -lmysqlclient" DRIVER_INCS_mysql=-I/usr/include/mysql LUA_SYS_VER=$LUA_VERSION
-          cd ..
+          make mysql DRIVER_LIBS_mysql="-L/usr/lib64/mysql -lmysqlclient" DRIVER_INCS_mysql=-I/usr/include/mysql LUA_SYS_VER="$LUA_VERSION"
+         cd ..
 
-          sed -i "s/@luaver@/$LUA_VERSION/g" dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
+          sed -i "s/@luaver@/${LUA_VERSION}/g" dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
         shell: bash
 
       - name: Package

--- a/.github/workflows/lua-tz.yml
+++ b/.github/workflows/lua-tz.yml
@@ -89,6 +89,51 @@ jobs:
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-environment.outputs.stability }}
 
+  test-packages:
+    needs: [get-environment, package]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package_extension: rpm
+            image: almalinux:8
+            distrib: el8
+          - package_extension: rpm
+            image: almalinux:9
+            distrib: el9
+          - package_extension: deb
+            image: debian:bullseye
+            distrib: bullseye
+          - package_extension: deb
+            image: debian:bookworm
+            distrib: bookworm
+          - package_extension: deb
+            image: ubuntu:jammy
+            distrib: jammy
+
+    runs-on: ubuntu-24.04
+    container:
+      image: ${{ matrix.image }}
+
+    name: Test lua packages on ${{ matrix.package_extension }} ${{ matrix.distrib }}
+    steps:
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Test packaged libs
+        uses: ./.github/actions/test-packages
+        with:
+          package_extension: ${{ matrix.package_extension }}
+          distrib: ${{ matrix.distrib }}
+          arch: ${{ matrix.arch }}
+
+      - name: Upload error log
+        if: failure()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: install_error_log_${{ matrix.distrib }}-${{ matrix.arch }}
+          path: install_error_${{ matrix.distrib }}_${{ matrix.arch }}.log
+
   deliver-rpm:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
     needs: [get-environment, package]

--- a/.github/workflows/lua-tz.yml
+++ b/.github/workflows/lua-tz.yml
@@ -120,8 +120,7 @@ jobs:
 
     name: Test lua packages on ${{ matrix.package_extension }} ${{ matrix.distrib }}
     steps:
-
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Test packaged libs
         uses: ./.github/actions/test-packages

--- a/.github/workflows/lua-tz.yml
+++ b/.github/workflows/lua-tz.yml
@@ -125,14 +125,13 @@ jobs:
         with:
           package_extension: ${{ matrix.package_extension }}
           distrib: ${{ matrix.distrib }}
-          arch: ${{ matrix.arch }}
 
       - name: Upload error log
         if: failure()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: install_error_log_${{ matrix.distrib }}-${{ matrix.arch }}
-          path: install_error_${{ matrix.distrib }}_${{ matrix.arch }}.log
+          name: install_error_log_${{ matrix.distrib }}
+          path: install_error_${{ matrix.distrib }}.log
 
   deliver-rpm:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}

--- a/.github/workflows/lua-tz.yml
+++ b/.github/workflows/lua-tz.yml
@@ -90,6 +90,7 @@ jobs:
           rpm_gpg_signing_key_id: ${{ secrets.RPM_GPG_SIGNING_KEY_ID }}
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-environment.outputs.stability }}
+          artifact_name: "package-lua-tz-${{ matrix.distrib }}"
 
   test-packages:
     needs: [get-environment, package]

--- a/.github/workflows/lua-tz.yml
+++ b/.github/workflows/lua-tz.yml
@@ -125,6 +125,7 @@ jobs:
         with:
           package_extension: ${{ matrix.package_extension }}
           distrib: ${{ matrix.distrib }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-lua-tz-${{ matrix.distrib }}
 
       - name: Upload error log
         if: failure()

--- a/.github/workflows/lua-tz.yml
+++ b/.github/workflows/lua-tz.yml
@@ -8,14 +8,15 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - dependencies/lua-tz/**
+      - '.github/workflows/lua-tz.yml'
+      - 'dependencies/lua-tz/**'
   push:
     branches:
       - develop
       - master
     paths:
-      - dependencies/lua-tz/**
-      - .github/workflows/lua-tz.yml
+      - '.github/workflows/lua-tz.yml'
+      - 'dependencies/lua-tz/**'
 
 jobs:
   dependency-scan:

--- a/.github/workflows/lua-tz.yml
+++ b/.github/workflows/lua-tz.yml
@@ -48,7 +48,7 @@ jobs:
             image: packaging-stream-connectors-nfpm-jammy
             distrib: jammy
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     container:
       image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:latest
@@ -92,7 +92,7 @@ jobs:
   deliver-rpm:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
     needs: [get-environment, package]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         distrib: [el8, el9]
@@ -114,7 +114,7 @@ jobs:
   deliver-deb:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
     needs: [get-environment, package]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         distrib: [bullseye, bookworm, jammy]

--- a/.github/workflows/lua-tz.yml
+++ b/.github/workflows/lua-tz.yml
@@ -15,6 +15,7 @@ on:
       - master
     paths:
       - dependencies/lua-tz/**
+      - .github/workflows/lua-tz.yml
 
 jobs:
   dependency-scan:

--- a/.github/workflows/stream-connectors-lib.yml
+++ b/.github/workflows/stream-connectors-lib.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - .github/workflows/stream-connectors-lib.yml
       - packaging/connectors-lib/**
       - modules/centreon-stream-connectors-lib/**
   push:

--- a/.github/workflows/stream-connectors-lib.yml
+++ b/.github/workflows/stream-connectors-lib.yml
@@ -81,6 +81,7 @@ jobs:
           rpm_gpg_signing_key_id: ${{ secrets.RPM_GPG_SIGNING_KEY_ID }}
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-environment.outputs.stability }}
+          artifact_name: "package-stream-connectors-lib-${{ matrix.distrib }}"
 
   deliver-rpm:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}

--- a/.github/workflows/stream-connectors-lib.yml
+++ b/.github/workflows/stream-connectors-lib.yml
@@ -50,7 +50,7 @@ jobs:
             image: packaging-stream-connectors-nfpm-jammy
             distrib: jammy
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     container:
       image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:latest
@@ -83,7 +83,7 @@ jobs:
   deliver-rpm:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
     needs: [get-environment, package]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         distrib: [el8, el9]
@@ -105,7 +105,7 @@ jobs:
   deliver-deb:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
     needs: [get-environment, package]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         distrib: [bullseye, bookworm, jammy]

--- a/.github/workflows/stream-connectors-lib.yml
+++ b/.github/workflows/stream-connectors-lib.yml
@@ -8,16 +8,17 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - .github/workflows/stream-connectors-lib.yml
-      - packaging/connectors-lib/**
-      - modules/centreon-stream-connectors-lib/**
+      - '.github/workflows/stream-connectors-lib.yml'
+      - 'packaging/connectors-lib/**'
+      - 'modules/centreon-stream-connectors-lib/**'
   push:
     branches:
       - develop
       - master
     paths:
-      - packaging/connectors-lib/**
-      - modules/centreon-stream-connectors-lib/**
+      - '.github/workflows/stream-connectors-lib.yml'
+      - 'packaging/connectors-lib/**'
+      - 'modules/centreon-stream-connectors-lib/**'
 
 jobs:
   dependency-scan:

--- a/.github/workflows/stream-connectors-lib.yml
+++ b/.github/workflows/stream-connectors-lib.yml
@@ -71,8 +71,8 @@ jobs:
         with:
           nfpm_file_pattern: "packaging/connectors-lib/*.yaml"
           distrib: ${{ matrix.distrib }}
-          version: "3.7.0" # previous version:"3.6.1"
-          release: "2"
+          version: "3.8.0" # previous version:"3.7.0"
+          release: "1"
           package_extension: ${{ matrix.package_extension }}
           arch: all
           commit_hash: ${{ github.sha }}

--- a/.github/workflows/stream-connectors.yml
+++ b/.github/workflows/stream-connectors.yml
@@ -50,13 +50,16 @@ jobs:
 
       - name: Transform to directories
         id: list-connectors
+        env:
+          CONNECTOR_FILES: ${{ steps.filter.outputs.connectors_files }}
+          PACKAGING_CHANGED: ${{ steps.filter.outputs.packaging }}
         run: |
           folders=()
-          if [ "${{ steps.filter.outputs.packaging }}" = "true" ]; then
+          if [ "$PACKAGING_CHANGED" = "true" ]; then
             echo "Packaging files changed, adding all connectors"
             mapfile -t folders < <(find centreon-certified/ -maxdepth 1 -mindepth 1 -type d -exec basename {} \;)
           else
-            for f in ${{ steps.filter.outputs.connectors_files }}; do
+            for f in $CONNECTOR_FILES; do
               DIR_NAME=($(dirname $f))
               BASE_NAME=($(basename $DIR_NAME))
               echo "Adding $BASE_NAME to folders"
@@ -105,24 +108,28 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Replace package and connector name variables
+        env:
+          CONNECTOR_PATH: ${{ matrix.connector_path }}
         run: |
-          package_name="centreon-stream-connector-`basename ${{ matrix.connector_path }}`"
+          package_name="centreon-stream-connector-$(basename "$CONNECTOR_PATH")"
           sed -i "s/@PACKAGE_NAME@/$package_name/g" ./packaging/connectors/centreon-stream-connectors.yaml
-          connector_name="`basename ${{ matrix.connector_path }}`"
+          connector_name="$(basename "$CONNECTOR_PATH")"
           sed -i "s/@CONNECTOR_NAME@/$connector_name/g" ./packaging/connectors/centreon-stream-connectors.yaml
         shell: bash
 
       - name: Add specific dependencies
+        env:
+          CONNECTOR_PATH: ${{ matrix.connector_path }}
         run: |
           DEB_DEPENDENCIES=""
           RPM_DEPENDENCIES=""
-          if [ "${{ matrix.connector_path }}" = "kafka" ]; then
+          if [ "$CONNECTOR_PATH" = "kafka" ]; then
             DEB_DEPENDENCIES="librdkafka1,lua-cffi"
             RPM_DEPENDENCIES="librdkafka,lua-cffi"
-          elif [ "${{ matrix.connector_path }}" = "pagerduty" ]; then
+          elif [ "$CONNECTOR_PATH" = "pagerduty" ]; then
             DEB_DEPENDENCIES="lua-tz"
             RPM_DEPENDENCIES="lua-tz"
-          elif [ "${{ matrix.connector_path }}" = "splunk" ]; then
+          elif [ "$CONNECTOR_PATH" = "splunk" ]; then
             DEB_DEPENDENCIES="lua-tz"
             RPM_DEPENDENCIES="lua-tz"
           fi

--- a/.github/workflows/stream-connectors.yml
+++ b/.github/workflows/stream-connectors.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - '.github/workflows/stream-connectors.yml'
       - 'centreon-certified/**'
+      - 'packaging/connectors/**'
   push:
     branches:
       - develop
@@ -17,6 +18,7 @@ on:
     paths:
       - '.github/workflows/stream-connectors.yml'
       - 'centreon-certified/**'
+      - 'packaging/connectors/**'
 
 jobs:
   dependency-scan:
@@ -30,6 +32,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       connectors: ${{ steps.list-connectors.outputs.connectors }}
+      packaging: ${{ steps.filter.outputs.packaging }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -41,17 +44,25 @@ jobs:
           filters: |
             connectors:
               - added|modified: centreon-certified/**
+            packaging:
+              - modified: .github/workflows/stream-connectors.yml
+              - added|modified: packaging/connectors/**
 
-      - name: transform to directories
+      - name: Transform to directories
         id: list-connectors
         run: |
           folders=()
-          for f in ${{ steps.filter.outputs.connectors_files }}; do
-            DIR_NAME=($(dirname $f))
-            BASE_NAME=($(basename $DIR_NAME))
-            echo "Adding $BASE_NAME to folders"
-            folders+=($BASE_NAME)
-          done
+          if [ "${{ steps.filter.outputs.packaging }}" = "true" ]; then
+            echo "Packaging files changed, adding all connectors"
+            mapfile -t folders < <(find centreon-certified/ -maxdepth 1 -mindepth 1 -type d -exec basename {} \;)
+          else
+            for f in ${{ steps.filter.outputs.connectors_files }}; do
+              DIR_NAME=($(dirname $f))
+              BASE_NAME=($(basename $DIR_NAME))
+              echo "Adding $BASE_NAME to folders"
+              folders+=($BASE_NAME)
+            done
+          fi
           unique_folders=($(printf "%s\n" "${folders[@]}" | sort -u | tr '\n' ' '))
           echo "connectors=$(jq --compact-output --null-input '$ARGS.positional' --args -- ${unique_folders[@]})" >> $GITHUB_OUTPUT
         shell: bash
@@ -81,7 +92,7 @@ jobs:
             image: packaging-stream-connectors-nfpm-jammy
             package_extension: deb
 
-    name: package ${{ matrix.distrib }} ${{ matrix.connector_path }}
+    name: Package ${{ matrix.distrib }} ${{ matrix.connector_path }}
     container:
       image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:latest
       credentials:
@@ -148,7 +159,7 @@ jobs:
       matrix:
         distrib: [el8, el9]
         connector_path: ${{ fromJson(needs.detect-changes.outputs.connectors) }}
-    name: deliver ${{ matrix.distrib }} ${{ matrix.connector_path }}
+    name: Deliver ${{ matrix.distrib }} ${{ matrix.connector_path }}
 
     steps:
       - name: Checkout sources
@@ -171,7 +182,7 @@ jobs:
       matrix:
         distrib: [bullseye, bookworm, jammy]
         connector_path: ${{ fromJson(needs.detect-changes.outputs.connectors) }}
-    name: deliver ${{ matrix.distrib }} ${{ matrix.connector_path }}
+    name: Deliver ${{ matrix.distrib }} ${{ matrix.connector_path }}
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/stream-connectors.yml
+++ b/.github/workflows/stream-connectors.yml
@@ -8,14 +8,15 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - .github/workflows/stream-connectors.yml
-      - centreon-certified/**
+      - '.github/workflows/stream-connectors.yml'
+      - 'centreon-certified/**'
   push:
     branches:
       - develop
       - master
     paths:
-      - centreon-certified/**
+      - '.github/workflows/stream-connectors.yml'
+      - 'centreon-certified/**'
 
 jobs:
   dependency-scan:

--- a/.github/workflows/stream-connectors.yml
+++ b/.github/workflows/stream-connectors.yml
@@ -60,8 +60,8 @@ jobs:
             mapfile -t folders < <(find centreon-certified/ -maxdepth 1 -mindepth 1 -type d -exec basename {} \;)
           else
             for f in $CONNECTOR_FILES; do
-              DIR_NAME=($(dirname $f))
-              BASE_NAME=($(basename $DIR_NAME))
+              DIR_NAME="$(dirname "$f")"
+              BASE_NAME="$(basename "$DIR_NAME")"
               echo "Adding $BASE_NAME to folders"
               folders+=($BASE_NAME)
             done
@@ -112,9 +112,9 @@ jobs:
           CONNECTOR_PATH: ${{ matrix.connector_path }}
         run: |
           package_name="centreon-stream-connector-$(basename "$CONNECTOR_PATH")"
-          sed -i "s/@PACKAGE_NAME@/$package_name/g" ./packaging/connectors/centreon-stream-connectors.yaml
+          sed -i "s/@PACKAGE_NAME@/${package_name}/g" ./packaging/connectors/centreon-stream-connectors.yaml
           connector_name="$(basename "$CONNECTOR_PATH")"
-          sed -i "s/@CONNECTOR_NAME@/$connector_name/g" ./packaging/connectors/centreon-stream-connectors.yaml
+          sed -i "s/@CONNECTOR_NAME@/${connector_name}/g" ./packaging/connectors/centreon-stream-connectors.yaml
         shell: bash
 
       - name: Add specific dependencies

--- a/.github/workflows/stream-connectors.yml
+++ b/.github/workflows/stream-connectors.yml
@@ -150,6 +150,7 @@ jobs:
           rpm_gpg_signing_key_id: ${{ secrets.RPM_GPG_SIGNING_KEY_ID }}
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-environment.outputs.stability }}
+          artifact_name: "package-${{ matrix.connector_path }}-${{ matrix.distrib }}"
 
   deliver-rpm:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}

--- a/.github/workflows/stream-connectors.yml
+++ b/.github/workflows/stream-connectors.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - .github/workflows/stream-connectors.yml
       - centreon-certified/**
   push:
     branches:

--- a/.github/workflows/stream-connectors.yml
+++ b/.github/workflows/stream-connectors.yml
@@ -25,7 +25,7 @@ jobs:
     uses: ./.github/workflows/get-environment.yml
 
   detect-changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       connectors: ${{ steps.list-connectors.outputs.connectors }}
     steps:
@@ -57,7 +57,7 @@ jobs:
   package:
     if: ${{ needs.detect-changes.outputs.connectors != '[]' }}
     needs: [get-environment, detect-changes]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         distrib: [el8, el9, bullseye, bookworm, jammy]
@@ -141,7 +141,7 @@ jobs:
   deliver-rpm:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
     needs: [get-environment, detect-changes, package]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         distrib: [el8, el9]
@@ -164,7 +164,7 @@ jobs:
   deliver-deb:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
     needs: [get-environment, detect-changes, package]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         distrib: [bullseye, bookworm, jammy]

--- a/dependencies/lua-cffi/packaging/lua-cffi.yaml
+++ b/dependencies/lua-cffi/packaging/lua-cffi.yaml
@@ -32,7 +32,7 @@ overrides:
   deb:
     depends:
       - "lua@luaver@"
-      - "libffi7 | libffi8 | libffi9"
+      - "libffi7 | libffi8"
       - "libffi-dev"
 
 rpm:

--- a/dependencies/lua-cffi/packaging/lua-cffi.yaml
+++ b/dependencies/lua-cffi/packaging/lua-cffi.yaml
@@ -32,7 +32,7 @@ overrides:
   deb:
     depends:
       - "lua5.3"
-      - "libffi7"
+      - "libffi7 | libffi8 | libffi9"
       - "libffi-dev"
 
 rpm:

--- a/dependencies/lua-cffi/packaging/lua-cffi.yaml
+++ b/dependencies/lua-cffi/packaging/lua-cffi.yaml
@@ -20,7 +20,7 @@ contents:
     packager: rpm
 
   - src: "../lua-cffi/cffi.so"
-    dst: "/usr/lib/x86_64-linux-gnu/lua/5.3/cffi.so"
+    dst: "/usr/lib/x86_64-linux-gnu/lua/@luaver@/cffi.so"
     packager: deb
 
 overrides:
@@ -31,7 +31,7 @@ overrides:
       - libffi-devel
   deb:
     depends:
-      - "lua5.3"
+      - "lua@luaver@"
       - "libffi7 | libffi8 | libffi9"
       - "libffi-dev"
 

--- a/dependencies/lua-tz/packaging/lua-tz.yaml
+++ b/dependencies/lua-tz/packaging/lua-tz.yaml
@@ -20,7 +20,7 @@ contents:
     packager: rpm
 
   - src: "../lua-tz"
-    dst: "/usr/share/lua/5.3/luatz"
+    dst: "/usr/share/lua/@luaver@/luatz"
     packager: deb
 
 overrides:
@@ -29,7 +29,7 @@ overrides:
       - lua
   deb:
     depends:
-      - "lua5.3"
+      - "lua@luaver@"
 
 rpm:
   summary: lua tz

--- a/dependencies/lua-tz/packaging/lua-tz.yaml
+++ b/dependencies/lua-tz/packaging/lua-tz.yaml
@@ -27,9 +27,11 @@ overrides:
   rpm:
     depends:
       - lua
+      - tzdata
   deb:
     depends:
       - "lua@luaver@"
+      - tzdata
 
 rpm:
   summary: lua tz

--- a/packaging/connectors-lib/centreon-stream-connectors-lib.yaml
+++ b/packaging/connectors-lib/centreon-stream-connectors-lib.yaml
@@ -20,10 +20,7 @@ contents:
     packager: rpm
 
   - src: "../../modules/centreon-stream-connectors-lib"
-    dst: "/usr/share/lua/5.3/centreon-stream-connectors-lib"
-    packager: deb
-  - src: "../../modules/centreon-stream-connectors-lib"
-    dst: "/usr/share/lua/5.4/centreon-stream-connectors-lib"
+    dst: "/usr/share/lua/@luaver@/centreon-stream-connectors-lib"
     packager: deb
 
 overrides:
@@ -38,7 +35,7 @@ overrides:
       - "centreon-broker-core (>= 22.04.0)"
       - "lua-socket (>= 3.0~)"
       - "lua-curl (>= 0.3.13-10)"
-      - "lua5.3"
+      - "lua@luaver@"
 
 rpm:
   summary: Centreon stream connectors lua modules

--- a/packaging/connectors-lib/centreon-stream-connectors-lib.yaml
+++ b/packaging/connectors-lib/centreon-stream-connectors-lib.yaml
@@ -27,12 +27,12 @@ overrides:
   rpm:
     depends:
       - lua-socket >= 3.0
-      - centreon-broker-core >= 22.04.0
+      - centreon-broker-core >= 24.10.0
       - lua-curl >= 0.3.13-10
       - lua
   deb:
     depends:
-      - "centreon-broker-core (>= 22.04.0)"
+      - "centreon-broker-core (>= 24.10.0)"
       - "lua-socket (>= 3.0~)"
       - "lua-curl (>= 0.3.13-10)"
       - "lua@luaver@"

--- a/packaging/connectors/centreon-stream-connectors.yaml
+++ b/packaging/connectors/centreon-stream-connectors.yaml
@@ -21,12 +21,12 @@ contents:
 overrides:
   rpm:
     depends: [
-      centreon-stream-connectors-lib >= 3.7.0,
+      centreon-stream-connectors-lib >= 3.8.0,
       @RPM_DEPENDENCIES@
     ]
   deb:
     depends: [
-      "centreon-stream-connectors-lib (>= 3.7.0~)",
+      "centreon-stream-connectors-lib (>= 3.8.0~)",
       @DEB_DEPENDENCIES@
     ]
 rpm:

--- a/tests/packaging/lua-cffi.lua
+++ b/tests/packaging/lua-cffi.lua
@@ -1,0 +1,46 @@
+#!/usr/bin/env lua
+
+-- Check if the module can be loaded
+local status, ffi = pcall(require, 'cffi')
+
+if not status then
+  print("ERROR: Unable to load cffi module")
+  print(ffi)
+  os.exit(1)
+end
+
+print("✓ cffi module loaded successfully")
+
+-- Basic test: define a C structure
+local ok, err = pcall(function()
+  ffi.cdef[[
+    typedef struct { int x; int y; } point_t;
+  ]]
+end)
+
+if not ok then
+  print("ERROR: Unable to define C structure")
+  print(err)
+  os.exit(1)
+end
+
+print("✓ C structure definition successful")
+
+-- Create and test an instance
+local ok, point = pcall(function()
+  return ffi.new('point_t', {x = 10, y = 20})
+end)
+
+if not ok then
+  print("ERROR: Unable to create instance")
+  print(point)
+  os.exit(1)
+end
+
+if point.x ~= 10 or point.y ~= 20 then
+  print("ERROR: Values do not match")
+  os.exit(1)
+end
+
+print("✓ Instance creation and data access successful")
+print("\nAll tests passed - lua-cffi is working correctly!")

--- a/tests/packaging/lua-sql-mysql.lua
+++ b/tests/packaging/lua-sql-mysql.lua
@@ -1,0 +1,52 @@
+#!/usr/bin/env lua
+
+-- Check if the module can be loaded
+local status, luasql = pcall(require, 'luasql.mysql')
+
+if not status then
+  print("ERROR: Unable to load luasql.mysql module")
+  print(luasql)
+  os.exit(1)
+end
+
+print("✓ luasql.mysql module loaded successfully")
+
+-- Check that the environment can be created
+local ok, env = pcall(luasql.mysql)
+
+if not ok then
+  print("ERROR: Unable to create MySQL environment")
+  print(env)
+  os.exit(1)
+end
+
+print("✓ MySQL environment created successfully")
+
+-- Verify environment type
+if type(env) ~= "userdata" then
+  print("ERROR: Environment is not of the expected type")
+  os.exit(1)
+end
+
+print("✓ Environment type is correct")
+
+-- Test connection attempt with invalid parameters (should fail gracefully)
+local conn, err = env:connect("test_db", "test_user", "test_pass", "localhost", 3306)
+
+if conn then
+  print("✓ Connection object created (MySQL server may be running)")
+  conn:close()
+else
+  -- Expected behavior when MySQL is not running
+  if err and type(err) == "string" then
+    print("✓ Connection failed as expected (no MySQL server): " .. err)
+  else
+    print("✓ Connection failed as expected (no MySQL server)")
+  end
+end
+
+-- Close environment
+env:close()
+print("✓ Environment closed successfully")
+
+print("\nAll tests passed - lua-sql-mysql is working correctly!")

--- a/tests/packaging/lua-tz.lua
+++ b/tests/packaging/lua-tz.lua
@@ -1,78 +1,67 @@
 #!/usr/bin/env lua
 
--- Check if the module can be loaded
-local status, luatz = pcall(require, 'luatz')
+-- Examples from the luatz repository
 
-if not status then
-  print("ERROR: Unable to load luatz module")
-  print(luatz)
-  os.exit(1)
+local luatz = require "luatz"
+
+-- We do this a few times ==> Convert a timestamp to timetable and normalise
+local function ts2tt(ts)
+	return luatz.timetable.new_from_timestamp(ts)
 end
 
-print("✓ luatz module loaded successfully")
+-- Get the current time in UTC
+local utcnow = luatz.time()
+local now = ts2tt(utcnow)
+print(now, "now (UTC)")
 
--- Test basic functionality: get current time
-local ok, now = pcall(function()
-  return luatz.time()
-end)
+-- Get a new time object 6 months from now
+local x = now:clone()
+x.month = x.month + 6
+x:normalise()
+print(x, "6 months from now")
 
-if not ok then
-  print("ERROR: Unable to get current time")
-  print(now)
-  os.exit(1)
+-- Find out what time it is in Melbourne at the moment
+local melbourne = luatz.get_tz("Australia/Melbourne")
+local now_in_melbourne = ts2tt(melbourne:localise(utcnow))
+print(now_in_melbourne, "Melbourne")
+
+-- Six months from now in melbourne (so month is incremented; but still the same time)
+local m = now_in_melbourne:clone()
+m.month = m.month + 6
+m:normalise()
+print(m, "6 months from now in melbourne")
+
+-- Convert time back to utc; a daylight savings transition may have taken place!
+-- There may be 2 results, but for we'll ignore the second possibility
+local c, _ = melbourne:utctime(m:timestamp())
+print(ts2tt(c), "6 months from now in melbourne converted to utc")
+
+
+--[[
+Re-implementation of `os.date` from the standard lua library
+]]
+
+local gettime = require "luatz.gettime".gettime
+local new_from_timestamp = require "luatz.timetable".new_from_timestamp
+local get_tz = require "luatz.tzcache".get_tz
+
+local function os_date(format_string, timestamp)
+	format_string = format_string or "%c"
+	timestamp = timestamp or gettime()
+	if format_string:sub(1, 1) == "!" then -- UTC
+		format_string = format_string:sub(2)
+	else -- Localtime
+		timestamp = get_tz():localise(timestamp)
+	end
+	local tt = new_from_timestamp(timestamp)
+	if format_string == "*t" then
+		return tt
+	else
+		return tt:strftime(format_string)
+	end
 end
 
-print("✓ Current time retrieved successfully: " .. now)
-
--- Test timezone parsing
-local ok, tz = pcall(function()
-  return luatz.time_in(nil)
-end)
-
-if not ok then
-  print("ERROR: Unable to create time_in object")
-  print(tz)
-  os.exit(1)
-end
-
-print("✓ time_in object created successfully")
-
--- Test timestamp conversion
-local ok, ts = pcall(function()
-  local t = luatz.timetable()
-  t.year = 2024
-  t.month = 1
-  t.day = 1
-  t.hour = 0
-  t.min = 0
-  t.sec = 0
-  return t:timestamp()
-end)
-
-if not ok then
-  print("ERROR: Unable to convert timetable to timestamp")
-  print(ts)
-  os.exit(1)
-end
-
-print("✓ Timetable to timestamp conversion successful: " .. ts)
-
--- Test timestamp parsing
-local ok, tt = pcall(function()
-  return luatz.timetable.new_from_timestamp(ts)
-end)
-
-if not ok then
-  print("ERROR: Unable to parse timestamp")
-  print(tt)
-  os.exit(1)
-end
-
-if tt.year ~= 2024 or tt.month ~= 1 or tt.day ~= 1 then
-  print("ERROR: Parsed values do not match")
-  os.exit(1)
-end
-
-print("✓ Timestamp parsing successful")
-
-print("\nAll tests passed - lua-tz is working correctly!")
+print(os_date())
+print(os_date("%Y-%m-%d %H:%M:%S"))
+print(os_date("!%Y-%m-%d %H:%M:%S", utcnow))
+print(os_date("*t", utcnow + 3600 * 24 * 30))

--- a/tests/packaging/lua-tz.lua
+++ b/tests/packaging/lua-tz.lua
@@ -1,0 +1,78 @@
+#!/usr/bin/env lua
+
+-- Check if the module can be loaded
+local status, luatz = pcall(require, 'luatz')
+
+if not status then
+  print("ERROR: Unable to load luatz module")
+  print(luatz)
+  os.exit(1)
+end
+
+print("✓ luatz module loaded successfully")
+
+-- Test basic functionality: get current time
+local ok, now = pcall(function()
+  return luatz.time()
+end)
+
+if not ok then
+  print("ERROR: Unable to get current time")
+  print(now)
+  os.exit(1)
+end
+
+print("✓ Current time retrieved successfully: " .. now)
+
+-- Test timezone parsing
+local ok, tz = pcall(function()
+  return luatz.time_in(nil)
+end)
+
+if not ok then
+  print("ERROR: Unable to create time_in object")
+  print(tz)
+  os.exit(1)
+end
+
+print("✓ time_in object created successfully")
+
+-- Test timestamp conversion
+local ok, ts = pcall(function()
+  local t = luatz.timetable()
+  t.year = 2024
+  t.month = 1
+  t.day = 1
+  t.hour = 0
+  t.min = 0
+  t.sec = 0
+  return t:timestamp()
+end)
+
+if not ok then
+  print("ERROR: Unable to convert timetable to timestamp")
+  print(ts)
+  os.exit(1)
+end
+
+print("✓ Timetable to timestamp conversion successful: " .. ts)
+
+-- Test timestamp parsing
+local ok, tt = pcall(function()
+  return luatz.timetable.new_from_timestamp(ts)
+end)
+
+if not ok then
+  print("ERROR: Unable to parse timestamp")
+  print(tt)
+  os.exit(1)
+end
+
+if tt.year ~= 2024 or tt.month ~= 1 or tt.day ~= 1 then
+  print("ERROR: Parsed values do not match")
+  os.exit(1)
+end
+
+print("✓ Timestamp parsing successful")
+
+print("\nAll tests passed - lua-tz is working correctly!")


### PR DESCRIPTION
## Description

libffi7 is set as dependency for all debian/ubuntu distributions, but for debian 12 and ubuntu, only libffi8 is available.

And little updates : 
- add a default value for REGISTRY_URL in docker images
- update ubuntu runner version for CI
- use lua 5.4 instead of 5.3 for debian
- improve GHA workflows

**Fixes** CTOR-2125

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Try to install the Kafka stream connector.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 4 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added default REGISTRY_URL build arg to multiple Dockerfiles
* Updated GitHub Actions runners from ubuntu-22.04 to ubuntu-24.04
* Added test-packages jobs and artifact naming for package workflows
* Parameterized packaging and updated lua paths, dependencies, and versions

**🐛 Bugfixes**
* Allowed deb packages to accept libffi8 where libffi7 was unavailable


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98798492?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->