### PR TITLE
enh(ci): deliver centreon stream connectors for debian 13, rhel 10 and noble

### DIFF
--- a/.github/actions/deb-delivery/action.yml
+++ b/.github/actions/deb-delivery/action.yml
@@ -43,7 +43,7 @@ runs:
       run: |
         FILES="*.deb"
 
-        if [[ "$DISTRIB" == "jammy" ]]; then
+        if [[ "$DISTRIB" == "jammy" || "$DISTRIB" == "noble" ]]; then
           REPO_PREFIX="ubuntu"
         else
           REPO_PREFIX="apt"

--- a/.github/actions/deb-delivery/action.yml
+++ b/.github/actions/deb-delivery/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - if: ${{ ! (inputs.distrib == 'jammy' && inputs.stability == 'stable') }}
       name: Use cache DEB files
-      uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ./*.deb
         key: ${{ inputs.cache_key }}

--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -104,7 +104,7 @@ runs:
       shell: bash
 
     - name: Cache packages
-      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ./*.${{ inputs.package_extension }}
         key: ${{ inputs.cache_key }}

--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Use cache RPM files
-      uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ./*.rpm
         key: ${{ inputs.cache_key }}

--- a/.github/actions/test-packages/action.yml
+++ b/.github/actions/test-packages/action.yml
@@ -37,7 +37,7 @@ runs:
       shell: bash
 
     - name: Restore packages from cache
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ./*.${{ inputs.package_extension }}
         key: ${{ inputs.cache_key }}

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-alma10
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-alma10
@@ -1,0 +1,19 @@
+ARG REGISTRY_URL=docker.centreon.com/centreon
+
+FROM ${REGISTRY_URL}/almalinux:10
+
+RUN bash -e <<EOF
+
+dnf install -y dnf-plugins-core epel-release
+dnf config-manager --set-enabled crb
+
+echo '[goreleaser]
+name=GoReleaser
+baseurl=https://repo.goreleaser.com/yum/
+enabled=1
+gpgcheck=0' | tee /etc/yum.repos.d/goreleaser.repo
+
+dnf install -y git zstd nfpm-2.35.2 lua lua-devel
+dnf clean all
+
+EOF

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-noble
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-noble
@@ -1,6 +1,6 @@
 ARG REGISTRY_URL=docker.centreon.com/centreon
 
-FROM ${REGISTRY_URL}/ubuntu:jammy
+FROM ${REGISTRY_URL}/ubuntu:noble
 
 RUN bash -e <<EOF
 

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-noble
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-noble
@@ -1,0 +1,17 @@
+ARG REGISTRY_URL=docker.centreon.com/centreon
+
+FROM ${REGISTRY_URL}/ubuntu:jammy
+
+RUN bash -e <<EOF
+
+apt-get update
+apt-get install -y git zstd ca-certificates lua5.3 liblua5.3-dev
+
+echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
+
+apt-get update
+apt-get install -y nfpm=2.35.2
+
+apt-get clean
+
+EOF

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-trixie
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-trixie
@@ -1,0 +1,17 @@
+ARG REGISTRY_URL=docker.centreon.com/centreon
+
+FROM ${REGISTRY_URL}/debian:bookworm
+
+RUN bash -e <<EOF
+
+apt-get update
+apt-get install -y git zstd ca-certificates lua5.3 liblua5.3-dev
+
+echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
+
+apt-get update
+apt-get install -y nfpm=2.35.2
+
+apt-get clean
+
+EOF

--- a/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-trixie
+++ b/.github/docker/Dockerfile.packaging-stream-connectors-nfpm-trixie
@@ -1,6 +1,6 @@
 ARG REGISTRY_URL=docker.centreon.com/centreon
 
-FROM ${REGISTRY_URL}/debian:bookworm
+FROM ${REGISTRY_URL}/debian:trixie
 
 RUN bash -e <<EOF
 

--- a/.github/workflows/docker-packaging.yml
+++ b/.github/workflows/docker-packaging.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        distrib: [alma8, alma9, bullseye, bookworm, jammy]
+        distrib: [alma8, alma9, alma10, bullseye, bookworm, trixie, jammy, noble]
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/lua-cffi.yml
+++ b/.github/workflows/lua-cffi.yml
@@ -105,7 +105,7 @@ jobs:
           cd cffi-lua-src
           mkdir build
           cd build
-          if [ "$DISTRIB" = "el9" ]; then
+          if [[ "$DISTRIB" = "el9" || "$DISTRIB" = "el10" ]]; then
             meson .. -Dlua_version=5.4
           else
             meson .. -Dlua_version=5.3

--- a/.github/workflows/lua-cffi.yml
+++ b/.github/workflows/lua-cffi.yml
@@ -187,7 +187,7 @@ jobs:
 
   deliver-rpm:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
-    needs: [get-environment, package]
+    needs: [get-environment, package, test-packages]
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -209,7 +209,7 @@ jobs:
 
   deliver-deb:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
-    needs: [get-environment, package]
+    needs: [get-environment, package, test-packages]
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/lua-cffi.yml
+++ b/.github/workflows/lua-cffi.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [el8, el9, bullseye, bookworm, jammy]
+        distrib: [el8, el9, el10, bullseye, bookworm, trixie, jammy, noble]
         include:
           - package_extension: rpm
             image: packaging-stream-connectors-nfpm-alma8
@@ -40,6 +40,9 @@ jobs:
           - package_extension: rpm
             image: packaging-stream-connectors-nfpm-alma9
             distrib: el9
+          - package_extension: rpm
+            image: packaging-stream-connectors-nfpm-alma10
+            distrib: el10
           - package_extension: deb
             image: packaging-stream-connectors-nfpm-bullseye
             distrib: bullseye
@@ -47,8 +50,14 @@ jobs:
             image: packaging-stream-connectors-nfpm-bookworm
             distrib: bookworm
           - package_extension: deb
+            image: packaging-stream-connectors-nfpm-trixie
+            distrib: trixie
+          - package_extension: deb
             image: packaging-stream-connectors-nfpm-jammy
             distrib: jammy
+          - package_extension: deb
+            image: packaging-stream-connectors-nfpm-noble
+            distrib: noble
 
     runs-on: ubuntu-24.04
 
@@ -136,6 +145,9 @@ jobs:
           - package_extension: rpm
             image: almalinux:9
             distrib: el9
+          - package_extension: rpm
+            image: almalinux:10
+            distrib: el10
           - package_extension: deb
             image: debian:bullseye
             distrib: bullseye
@@ -143,8 +155,14 @@ jobs:
             image: debian:bookworm
             distrib: bookworm
           - package_extension: deb
+            image: debian:trixie
+            distrib: trixie
+          - package_extension: deb
             image: ubuntu:jammy
             distrib: jammy
+          - package_extension: deb
+            image: ubuntu:noble
+            distrib: noble
     runs-on: ubuntu-24.04
     container:
       image: ${{ matrix.image }}
@@ -173,7 +191,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        distrib: [el8, el9]
+        distrib: [el8, el9, el10]
     name: deliver ${{ matrix.distrib }}
 
     steps:
@@ -195,7 +213,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        distrib: [bullseye, bookworm, jammy]
+        distrib: [bullseye, bookworm, trixie, jammy, noble]
     name: deliver ${{ matrix.distrib }}
 
     steps:

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -32,13 +32,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [el8, el9]
+        distrib: [el8, el9, el10]
         include:
           - image: packaging-stream-connectors-nfpm-alma8
             distrib: el8
             lua_version: 5.3
           - image: packaging-stream-connectors-nfpm-alma9
             distrib: el9
+            lua_version: 5.4
+          - image: packaging-stream-connectors-nfpm-alma10
+            distrib: el10
             lua_version: 5.4
 
     runs-on: ubuntu-24.04
@@ -60,7 +63,7 @@ jobs:
         with:
           repository: "lunarmodules/luasql"
           path: "lua-sql-src"
-          ref: "2.6.0"
+          ref: "2.7.0"
 
       - name: Prepare packaging of lua-sql-mysql
         env:
@@ -88,7 +91,7 @@ jobs:
           distrib: ${{ matrix.distrib }}
           package_extension: rpm
           arch: amd64
-          version: "2.6.0"
+          version: "2.7.0"
           release: "1"
           commit_hash: ${{ github.sha }}
           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-lua-sql-mysql-${{ matrix.distrib }}
@@ -110,6 +113,9 @@ jobs:
           - package_extension: rpm
             image: almalinux:9
             distrib: el9
+          - package_extension: rpm
+            image: almalinux:10
+            distrib: el10
 
     runs-on: ubuntu-24.04
     container:
@@ -139,7 +145,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        distrib: [el8, el9]
+        distrib: [el8, el9, el10]
     name: deliver ${{ matrix.distrib }}
 
     steps:

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -76,7 +76,7 @@ jobs:
           else
             dnf config-manager --set-enabled crb
           fi
-          dnf install -y make gcc lua lua-devel mysql mysql-devel
+          dnf install -y make gcc lua lua-devel
           if [ "$DISTRIB" == "el10" ]; then
             dnf install -y mysql8.4 mysql8.4-devel
           else

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -77,6 +77,11 @@ jobs:
             dnf config-manager --set-enabled crb
           fi
           dnf install -y make gcc lua lua-devel mysql mysql-devel
+          if [ "$DISTRIB" == "el10" ]; then
+            dnf install -y mysql8.4 mysql8.4-devel
+          else
+            dnf install -y mysql mysql-devel
+          fi
           cd lua-sql-src
           make mysql DRIVER_LIBS_mysql="-L/usr/lib64/mysql -lmysqlclient" DRIVER_INCS_mysql=-I/usr/include/mysql LUA_SYS_VER="$LUA_VERSION"
           cd ..
@@ -141,7 +146,7 @@ jobs:
 
   deliver-rpm:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
-    needs: [get-environment, package]
+    needs: [get-environment, package, test-packages]
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/lua-sql-mysql.yml
+++ b/.github/workflows/lua-sql-mysql.yml
@@ -76,17 +76,17 @@ jobs:
           else
             dnf config-manager --set-enabled crb
           fi
-          dnf install -y make gcc lua lua-devel
+          MYSQL_VERSION=""
           if [ "$DISTRIB" == "el10" ]; then
-            dnf install -y mysql8.4 mysql8.4-devel
-          else
-            dnf install -y mysql mysql-devel
+            MYSQL_VERSION="8.4"
           fi
+          dnf install -y make gcc lua lua-devel mysql$MYSQL_VERSION mysql$MYSQL_VERSION-devel
           cd lua-sql-src
           make mysql DRIVER_LIBS_mysql="-L/usr/lib64/mysql -lmysqlclient" DRIVER_INCS_mysql=-I/usr/include/mysql LUA_SYS_VER="$LUA_VERSION"
           cd ..
 
           sed -i "s/@luaver@/${LUA_VERSION}/g" dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
+          sed -i "s/@mysql_version@/${MYSQL_VERSION}/g" dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
         shell: bash
 
       - name: Package

--- a/.github/workflows/lua-tz.yml
+++ b/.github/workflows/lua-tz.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [el8, el9, bullseye, bookworm, jammy]
+        distrib: [el8, el9, el10, bullseye, bookworm, trixie, jammy, noble]
         include:
           - package_extension: rpm
             image: packaging-stream-connectors-nfpm-alma8
@@ -40,6 +40,9 @@ jobs:
           - package_extension: rpm
             image: packaging-stream-connectors-nfpm-alma9
             distrib: el9
+          - package_extension: rpm
+            image: packaging-stream-connectors-nfpm-alma10
+            distrib: el10
           - package_extension: deb
             image: packaging-stream-connectors-nfpm-bullseye
             distrib: bullseye
@@ -47,8 +50,14 @@ jobs:
             image: packaging-stream-connectors-nfpm-bookworm
             distrib: bookworm
           - package_extension: deb
+            image: packaging-stream-connectors-nfpm-trixie
+            distrib: trixie
+          - package_extension: deb
             image: packaging-stream-connectors-nfpm-jammy
             distrib: jammy
+          - package_extension: deb
+            image: packaging-stream-connectors-nfpm-noble
+            distrib: noble
 
     runs-on: ubuntu-24.04
 
@@ -104,6 +113,9 @@ jobs:
           - package_extension: rpm
             image: almalinux:9
             distrib: el9
+          - package_extension: rpm
+            image: almalinux:10
+            distrib: el10
           - package_extension: deb
             image: debian:bullseye
             distrib: bullseye
@@ -111,8 +123,14 @@ jobs:
             image: debian:bookworm
             distrib: bookworm
           - package_extension: deb
+            image: debian:trixie
+            distrib: trixie
+          - package_extension: deb
             image: ubuntu:jammy
             distrib: jammy
+          - package_extension: deb
+            image: ubuntu:noble
+            distrib: noble
 
     runs-on: ubuntu-24.04
     container:
@@ -142,7 +160,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        distrib: [el8, el9]
+        distrib: [el8, el9, el10]
     name: deliver ${{ matrix.distrib }}
 
     steps:
@@ -164,7 +182,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        distrib: [bullseye, bookworm, jammy]
+        distrib: [bullseye, bookworm, trixie, jammy, noble]
     name: deliver ${{ matrix.distrib }}
 
     steps:

--- a/.github/workflows/lua-tz.yml
+++ b/.github/workflows/lua-tz.yml
@@ -156,7 +156,7 @@ jobs:
 
   deliver-rpm:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
-    needs: [get-environment, package]
+    needs: [get-environment, package, test-packages]
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -178,7 +178,7 @@ jobs:
 
   deliver-deb:
     if: ${{ contains(fromJson('["unstable", "testing", "stable"]'), needs.get-environment.outputs.stability) }}
-    needs: [get-environment, package]
+    needs: [get-environment, package, test-packages]
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/stream-connectors-lib.yml
+++ b/.github/workflows/stream-connectors-lib.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [el8, el9, bullseye, bookworm, jammy]
+        distrib: [el8, el9, el10, bullseye, bookworm, trixie, jammy, noble]
         include:
           - package_extension: rpm
             image: packaging-stream-connectors-nfpm-alma8
@@ -42,6 +42,9 @@ jobs:
           - package_extension: rpm
             image: packaging-stream-connectors-nfpm-alma9
             distrib: el9
+          - package_extension: rpm
+            image: packaging-stream-connectors-nfpm-alma10
+            distrib: el10
           - package_extension: deb
             image: packaging-stream-connectors-nfpm-bullseye
             distrib: bullseye
@@ -49,8 +52,14 @@ jobs:
             image: packaging-stream-connectors-nfpm-bookworm
             distrib: bookworm
           - package_extension: deb
+            image: packaging-stream-connectors-nfpm-trixie
+            distrib: trixie
+          - package_extension: deb
             image: packaging-stream-connectors-nfpm-jammy
             distrib: jammy
+          - package_extension: deb
+            image: packaging-stream-connectors-nfpm-noble
+            distrib: noble
 
     runs-on: ubuntu-24.04
 
@@ -89,7 +98,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        distrib: [el8, el9]
+        distrib: [el8, el9, el10]
     name: deliver ${{ matrix.distrib }}
 
     steps:
@@ -111,7 +120,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        distrib: [bullseye, bookworm, jammy]
+        distrib: [bullseye, bookworm, trixie, jammy, noble]
     name: deliver ${{ matrix.distrib }}
 
     steps:

--- a/.github/workflows/stream-connectors.yml
+++ b/.github/workflows/stream-connectors.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        distrib: [el8, el9, bullseye, bookworm, jammy]
+        distrib: [el8, el9, el10, bullseye, bookworm, trixie, jammy, noble]
         connector_path: ${{ fromJson(needs.detect-changes.outputs.connectors) }}
         include:
           - distrib: el8
@@ -85,14 +85,23 @@ jobs:
           - distrib: el9
             image: packaging-stream-connectors-nfpm-alma9
             package_extension: rpm
+          - distrib: el10
+            image: packaging-stream-connectors-nfpm-alma10
+            package_extension: rpm
           - distrib: bullseye
             image: packaging-stream-connectors-nfpm-bullseye
             package_extension: deb
           - distrib: bookworm
             image: packaging-stream-connectors-nfpm-bookworm
             package_extension: deb
+          - distrib: trixie
+            image: packaging-stream-connectors-nfpm-trixie
+            package_extension: deb
           - distrib: jammy
             image: packaging-stream-connectors-nfpm-jammy
+            package_extension: deb
+          - distrib: noble
+            image: packaging-stream-connectors-nfpm-noble
             package_extension: deb
 
     name: Package ${{ matrix.distrib }} ${{ matrix.connector_path }}
@@ -165,7 +174,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        distrib: [el8, el9]
+        distrib: [el8, el9, el10]
         connector_path: ${{ fromJson(needs.detect-changes.outputs.connectors) }}
     name: Deliver ${{ matrix.distrib }} ${{ matrix.connector_path }}
 
@@ -188,7 +197,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        distrib: [bullseye, bookworm, jammy]
+        distrib: [bullseye, bookworm, trixie, jammy, noble]
         connector_path: ${{ fromJson(needs.detect-changes.outputs.connectors) }}
     name: Deliver ${{ matrix.distrib }} ${{ matrix.connector_path }}
 

--- a/dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
+++ b/dependencies/lua-sql-mysql/packaging/lua-sql-mysql.yaml
@@ -25,7 +25,7 @@ overrides:
   rpm:
     depends:
       - lua
-      - mysql-libs
+      - mysql@mysql_version@-libs
 
 rpm:
   summary: LuaSQL MySQL


### PR DESCRIPTION
## Description

Add stream connectors delivery for new distributions: el10, debian 13 and noble

**Fixes** CTOR-2314

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added packaging Dockerfiles and images for trixie, noble and alma10
* Expanded CI workflow matrices to include el10, trixie and noble
* Bumped dependency packaging versions and updated external checkout refs

**🐛 Bugfixes**
* Adjusted build steps for el10: meson/lua-cffi and mysql package handling

**🔧 Refactors**
* Upgraded GitHub actions cache usage to actions/cache v5 commit


<sup>[More info](https://app.aikido.dev/featurebranch/scan/111901247?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->