### PR TITLE
fix(lua-cffi): update version and release

### DIFF
--- a/.github/workflows/lua-cffi.yml
+++ b/.github/workflows/lua-cffi.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           repository: "q66/cffi-lua"
           path: "cffi-lua-src"
-          ref: "v0.2.3"
+          ref: "v0.2.4"
 
       - name: Prepare packaging of lua-cffi
         env:
@@ -124,7 +124,7 @@ jobs:
           package_extension: ${{ matrix.package_extension }}
           arch: amd64
           version: "0.2.4"
-          release: "1"
+          release: "2"
           commit_hash: ${{ github.sha }}
           cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-lua-cffi-${{ matrix.distrib }}
           rpm_gpg_key: ${{ secrets.RPM_GPG_SIGNING_KEY }}


### PR DESCRIPTION
## Description

Update the packaged lua-cffi version: 0.2.3 => 0.2.4
Update the release version: 0.2.4-1 was 0.2.3, so 0.2.4-2 will be 0.2.4
The fix for bookworm to depends on libffi8 instead of libffi7 (#317) will also be available for the tests of the next release.

**Fixes** CTOR-2125

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
