### PR TITLE
fix condition for canopsis ack event

### DIFF
--- a/centreon-certified/canopsis/canopsis2x-events-apiv2.lua
+++ b/centreon-certified/canopsis/canopsis2x-events-apiv2.lua
@@ -417,7 +417,7 @@ function EventQueue:format_event_acknowledgement()
     -- ack_resources = false
   }
 
-  if event.service_id then
+  if event.service_id and event.service_id ~= 0 then
     self.sc_event.event.formated_event['source_type'] = "resource"
     self.sc_event.event.formated_event['resource'] = tostring(event.cache.service.description)
     -- only with v2 api ?


### PR DESCRIPTION
## Description

ack format event fonction has an invalid condition that leads to an error when you put an ack on a host.

in the ack broker event, service_id value is equal to 0 when the ack event is related to a host.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
