### PR TITLE
ci(packaging): enable el10 and deb13 for the lib

### DIFF
--- a/.github/actions/test-packages/action.yml
+++ b/.github/actions/test-packages/action.yml
@@ -35,7 +35,7 @@ runs:
         if [[ "$DISTRIB" == "el8" || "$DISTRIB" == "el9" ]]; then
           CENTREON_VERSION="25.10"
         else
-          CENTREON_VERSION="26.10"  # el10 - repo not yet available
+          CENTREON_VERSION="26.10"  # el10
         fi
         # Add Centreon plugins and standard repositories
         cat > /etc/yum.repos.d/centreon-plugins.repo << EOF
@@ -193,7 +193,7 @@ runs:
           new_repo_format=true
         elif [[ "$DISTRIB" == "trixie" ]]; then
           standard_base="apt-standard"
-          standard_distrib="${DISTRIB}-26.10"  # repo not yet available
+          standard_distrib="${DISTRIB}-26.10"
           plugins_prefix="apt-plugins"
           new_repo_format=true
         fi
@@ -204,7 +204,10 @@ runs:
               echo "deb https://packages.centreon.com/${standard_base}/ ${standard_distrib}-stable main" | tee /etc/apt/sources.list.d/centreon-standard.list
             fi
             if [[ "$use_standard_testing" == "true" ]]; then
-              echo "deb https://packages.centreon.com/${standard_base}/ ${standard_distrib}-testing main" | tee -a /etc/apt/sources.list.d/centreon-standard.list
+              # The new repo format splits testing into release and hotfix suites, like the rpm one.
+              # The aggregated "-testing" suite only exists for bookworm and is not published for trixie.
+              echo "deb https://packages.centreon.com/${standard_base}/ ${standard_distrib}-testing-release main" | tee -a /etc/apt/sources.list.d/centreon-standard.list
+              echo "deb https://packages.centreon.com/${standard_base}/ ${standard_distrib}-testing-hotfix main" | tee -a /etc/apt/sources.list.d/centreon-standard.list
             fi
             if [[ "$use_standard_unstable" == "true" ]]; then
               echo "deb https://packages.centreon.com/${standard_base}/ ${standard_distrib}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-standard.list

--- a/.github/workflows/stream-connectors-lib.yml
+++ b/.github/workflows/stream-connectors-lib.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [el8, el9, bullseye, bookworm, jammy, noble] #, el10, trixie]
+        distrib: [el8, el9, el10, bullseye, bookworm, trixie, jammy, noble]
         include:
           - package_extension: rpm
             image: packaging-stream-connectors-nfpm-alma8
@@ -42,18 +42,18 @@ jobs:
           - package_extension: rpm
             image: packaging-stream-connectors-nfpm-alma9
             distrib: el9
-#          - package_extension: rpm
-#            image: packaging-stream-connectors-nfpm-alma10
-#            distrib: el10
+          - package_extension: rpm
+            image: packaging-stream-connectors-nfpm-alma10
+            distrib: el10
           - package_extension: deb
             image: packaging-stream-connectors-nfpm-bullseye
             distrib: bullseye
           - package_extension: deb
             image: packaging-stream-connectors-nfpm-bookworm
             distrib: bookworm
-#          - package_extension: deb
-#            image: packaging-stream-connectors-nfpm-trixie
-#            distrib: trixie
+          - package_extension: deb
+            image: packaging-stream-connectors-nfpm-trixie
+            distrib: trixie
           - package_extension: deb
             image: packaging-stream-connectors-nfpm-jammy
             distrib: jammy
@@ -104,18 +104,18 @@ jobs:
           - package_extension: rpm
             image: almalinux:9
             distrib: el9
-#          - package_extension: rpm   # Centreon 26.10 repo not yet available
-#            image: almalinux:10
-#            distrib: el10
+          - package_extension: rpm
+            image: almalinux:10
+            distrib: el10
           - package_extension: deb
             image: debian:bullseye
             distrib: bullseye
           - package_extension: deb
             image: debian:bookworm
             distrib: bookworm
-#          - package_extension: deb   # Centreon 26.10 repo not yet available
-#            image: debian:trixie
-#            distrib: trixie
+          - package_extension: deb
+            image: debian:trixie
+            distrib: trixie
           - package_extension: deb
             image: ubuntu:jammy
             distrib: jammy
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        distrib: [el8, el9] #, el10]
+        distrib: [el8, el9, el10]
     name: deliver ${{ matrix.distrib }}
 
     steps:
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        distrib: [bullseye, bookworm, jammy, noble] #, trixie]
+        distrib: [bullseye, bookworm, trixie, jammy, noble]
     name: deliver ${{ matrix.distrib }}
 
     steps:


### PR DESCRIPTION
Fixes: [MON-206776](https://centreon.atlassian.net/browse/MON-206776) [CTOR-2410](https://centreon.atlassian.net/browse/CTOR-2410)

Part 1 of 2. Part 2 is #376, which enables the connectors themselves and must merge after this one.

## Description

Building the Centreon 26.09 AMI on AlmaLinux 10 fails because no `centreon-stream-connector-*` package exists for el10. `el10` and `trixie` were enabled by #339, then commented out by #357 because the Centreon 26.10 repositories were not published yet. They now exist for both distributions.

This PR re-enables them for `centreon-stream-connectors-lib` only, in the package, test and deliver matrices of `stream-connectors-lib.yml`.

### Why the library has to go first

The connectors test job installs the connector package built in its own run, but resolves `centreon-stream-connectors-lib` from the **published** repositories. The el10 and trixie libraries published today are stale, because delivery to them has been off since #357:

- **el10** - `centreon-stream-connectors-lib-3.8.0-1.el10` was built on 2026-05-05, before `ab81407` (#363) changed `google/auth/oauth.lua` from `require("crypto")` to `require("openssl")`. Connector tests fail with `module 'crypto' not found`.
- **trixie** - `centreon-stream-connectors-lib 3.8.0-1~trixie` declares `Depends: ... lua5.3` and installs under `/usr/share/lua/5.3/`. It pulls `lua5.3` into the test container, while `lua-curl`, `lua-cffi` and `lua-openssl` for trixie are all built for 5.4, so every connector loading one of them fails with `module not found`. It also still declares `centreon-broker-core (>= 24.10.0)` and lacks `lua-lsqlite3`.

Merging this PR publishes a current library to el10 and trixie unstable, which unblocks #376.

### apt suite fix

`.github/actions/test-packages` emitted the aggregated `<distrib>-<version>-testing` suite, which is not published for trixie: only `testing-release` and `testing-hotfix` exist, so `apt-get update` failed on a 404. The action now emits both suites, consistent with the rpm branch of the same action. `bookworm` has all three, so it is unaffected.

## Verification

The `stream-connectors-lib` workflow already ran green on this exact change (as part of #376's branch): `package el10`, `package trixie`, `test packages on rpm el10` and `test packages on deb trixie` all passed. That workflow tests the library it just built, which is why it succeeds where the connectors workflow does not.

`actionlint` and `yamllint` 1.35.1 pass locally with the CI flags and ruleset.

## Notes for reviewers

- `stream-connectors.yml` is untouched here, so the connectors workflow does not run on this PR.
- The fresh packages carry the same version as the stale ones (`3.8.0-1.el10`, `3.8.0-1~trixie`), so they replace them in place in Artifactory.

[MON-206776]: https://centreon.atlassian.net/browse/MON-206776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CTOR-2410]: https://centreon.atlassian.net/browse/CTOR-2410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ